### PR TITLE
v2.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ignore/
 .DS_Store
 **/.DS_Store
 docs
+test/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+2.0.1
+=====
+
+### Fixes
+- Command usage instructions are now shown if incorrect/not enough args are used
+- Store information was not properly reloaded after running `tebex secret`, causing errors until the server was restarted.
+- `/tebex lookup` now uses the appropriate endpoint
+- Some commands' usage instructions improperly included a `.` in the command name
+- `/tebex report` now properly sends all report information to Tebex
+
 2.0.0
 =====
 - Plugin has been rewritten from the ground up to include support for: **Bukkit**, **Spigot**, **PaperSpigot**, **Fabric**, **Velocity**, and **BungeeCord**.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 defaultTasks("shadowJar")
 
 group = "io.tebex"
-version = "2.0.0"
+version = "2.0.1"
 
 subprojects {
     plugins.apply("java")

--- a/bukkit/src/main/java/io/tebex/plugin/TebexPlugin.java
+++ b/bukkit/src/main/java/io/tebex/plugin/TebexPlugin.java
@@ -387,4 +387,9 @@ public final class TebexPlugin extends JavaPlugin implements Platform {
                 getServer().getOnlineMode()
         );
     }
+
+    @Override
+    public String getServerIp() {
+        return Bukkit.getIp();
+    }
 }

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
@@ -15,12 +15,17 @@ public class BanCommand extends SubCommand {
     public void execute(CommandSender sender, String[] args) {
         TebexPlugin platform = getPlatform();
 
+        if (args.length != 3) {
+            sender.sendMessage("§b[Tebex] §7Invalid command usage. Use /tebex " + this.getName() + " " + getUsage());
+            return;
+        }
+
         String playerName = args[0];
         String reason = args[1];
         String ip = args[2];
 
         if (!platform.isSetup()) {
-            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key.");
+            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key.");
             return;
         }
 
@@ -43,6 +48,6 @@ public class BanCommand extends SubCommand {
 
     @Override
     public String getUsage() {
-        return "<playerName> <ip> <reason>";
+        return "<playerName> <reason> <ip>";
     }
 }

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/CheckoutCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/CheckoutCommand.java
@@ -17,16 +17,21 @@ public class CheckoutCommand extends SubCommand {
         TebexPlugin platform = getPlatform();
 
         if (!platform.isSetup()) {
-            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key.");
+            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key.");
             return;
         }
 
-        int packageId = Integer.parseInt(args[0]);
+        if (args.length == 0) {
+            sender.sendMessage("§b[Tebex] §7Invalid command usage. Use /tebex " + this.getName() + " " + getUsage());
+            return;
+        }
+
         try {
+            int packageId = Integer.parseInt(args[0]);
             CheckoutUrl checkoutUrl = platform.getSDK().createCheckoutUrl(packageId, sender.getName()).get();
             sender.sendMessage("§b[Tebex] §7Checkout started! Click here to complete payment: " + checkoutUrl.getUrl());
         } catch (InterruptedException|ExecutionException e) {
-            sender.sendMessage("§b[Tebex] §7Failed to get checkout link for package: " + e.getMessage());
+            sender.sendMessage("§b[Tebex] §7Failed to get checkout link for package, check package ID: " + e.getMessage());
         }
     }
 

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/DebugCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/DebugCommand.java
@@ -18,6 +18,11 @@ public class DebugCommand extends SubCommand {
         ServerPlatformConfig config = platform.getPlatformConfig();
         YamlDocument configFile = config.getYamlDocument();
 
+        if (args.length != 1) {
+            sender.sendMessage("§b[Tebex] §7Invalid command usage. Use /tebex " + this.getName() + " " + getUsage());
+            return;
+        }
+
         boolean enableDebug = Boolean.parseBoolean(args[0]);
         if (enableDebug) {
             sender.sendMessage("§b[Tebex] §7Debug mode enabled.");

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/InfoCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/InfoCommand.java
@@ -19,7 +19,7 @@ public class InfoCommand extends SubCommand {
             sender.sendMessage("§b[Tebex] §7Server prices are in " +  platform.getStoreInformation().getStore().getCurrency().getIso4217());
             sender.sendMessage("§b[Tebex] §7Webstore domain " +  platform.getStoreInformation().getStore().getDomain());
         } else {
-            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key.");
+            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key.");
         }
     }
 

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/LookupCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/LookupCommand.java
@@ -17,7 +17,12 @@ public class LookupCommand extends SubCommand {
         TebexPlugin platform = getPlatform();
 
         if (!platform.isSetup()) {
-            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key.");
+            sender.sendMessage("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key.");
+            return;
+        }
+
+        if (args.length != 1) {
+            sender.sendMessage("§b[Tebex] §7Invalid command usage. Use /tebex " + this.getName() + " " + getUsage());
             return;
         }
 

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/ReportCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/ReportCommand.java
@@ -18,6 +18,11 @@ public class ReportCommand extends SubCommand {
         ServerPlatformConfig config = platform.getPlatformConfig();
         YamlDocument configFile = config.getYamlDocument();
 
+        if (args.length != 1) {
+            sender.sendMessage("§b[Tebex] §7Invalid command usage. Use /tebex " + this.getName() + " " + getUsage());
+            return;
+        }
+
         String message = args[0];
 
         if (message.isEmpty()) {

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/SecretCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/SecretCommand.java
@@ -3,6 +3,7 @@ package io.tebex.plugin.command.sub;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import io.tebex.plugin.TebexPlugin;
 import io.tebex.plugin.command.SubCommand;
+import io.tebex.plugin.gui.BuyGUI;
 import io.tebex.sdk.SDK;
 import io.tebex.sdk.exception.ServerNotFoundException;
 import io.tebex.sdk.platform.config.ServerPlatformConfig;
@@ -41,8 +42,14 @@ public class SecretCommand extends SubCommand {
                 sender.sendMessage("§b[Tebex] §7Failed to save config: " + e.getMessage());
             }
 
-            sender.sendMessage("§b[Tebex] §7Connected to §b" + serverInformation.getServer().getName() + "§7.");
+
+            platform.loadServerPlatformConfig(configFile);
+            platform.reloadConfig();
+            platform.setBuyGUI(new BuyGUI(platform));
+            platform.refreshListings();
             platform.configure();
+
+            sender.sendMessage("§b[Tebex] §7Connected to §b" + serverInformation.getServer().getName() + "§7.");
         }).exceptionally(ex -> {
             Throwable cause = ex.getCause();
 

--- a/bukkit/src/main/java/io/tebex/plugin/command/sub/SendLinkCommand.java
+++ b/bukkit/src/main/java/io/tebex/plugin/command/sub/SendLinkCommand.java
@@ -17,20 +17,26 @@ public class SendLinkCommand extends SubCommand {
     public void execute(CommandSender sender, String[] args) {
         TebexPlugin platform = getPlatform();
 
-        String username = args[0];
-        int packageId = Integer.parseInt(args[0]);
-
-        Player player = sender.getServer().getPlayer(username);
-        if (player == null) {
-            sender.sendMessage("§b[Tebex] §7Could not find a player with that name on the server.");
+        if (args.length != 2) {
+            sender.sendMessage("§b[Tebex] §7Invalid command usage. Use /tebex " + this.getName() + " " + getUsage());
             return;
         }
 
+        String username = args[0];
         try {
+            Player player = sender.getServer().getPlayer(username);
+            if (player == null) {
+                sender.sendMessage("§b[Tebex] §7Could not find a player with that name on the server.");
+                return;
+            }
+
+            int packageId = Integer.parseInt(args[1]);
             CheckoutUrl checkoutUrl = platform.getSDK().createCheckoutUrl(packageId, player.getUniqueId().toString()).get();
             sender.sendMessage("§b[Tebex] §7A checkout link has been created for you. Click here to complete payment: " + checkoutUrl.getUrl());
         } catch (InterruptedException|ExecutionException e) {
             sender.sendMessage("§b[Tebex] §7Failed to get checkout link for package: " + e.getMessage());
+        } catch (NumberFormatException e) {
+            sender.sendMessage("§b[Tebex] §7Package ID must be a number.");
         }
     }
 

--- a/bungeecord/src/main/java/io/tebex/plugin/TebexPlugin.java
+++ b/bungeecord/src/main/java/io/tebex/plugin/TebexPlugin.java
@@ -14,6 +14,8 @@ import io.tebex.sdk.platform.PlatformType;
 import io.tebex.sdk.platform.config.ProxyPlatformConfig;
 import io.tebex.sdk.request.response.ServerInformation;
 import io.tebex.sdk.util.FileUtils;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ListenerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
@@ -296,6 +298,19 @@ public class TebexPlugin extends Plugin implements Platform {
                 System.getProperty("os.arch"),
                 getProxy().getConfig().isOnlineMode()
         );
+    }
+
+    @Override
+    public String getServerIp() {
+        Iterator<ListenerInfo> listeners = ProxyServer.getInstance().getConfig().getListeners().iterator();
+        String ipStr;
+
+        if (listeners.hasNext()) {
+            ListenerInfo listener = listeners.next();
+            return listener.getHost().getAddress().getHostAddress();
+        } else {
+            return "0.0.0.0";
+        }
     }
 
     @Override

--- a/fabric/src/main/java/io/tebex/plugin/TebexPlugin.java
+++ b/fabric/src/main/java/io/tebex/plugin/TebexPlugin.java
@@ -304,6 +304,11 @@ public class TebexPlugin implements Platform, DedicatedServerModInitializer {
     }
 
     @Override
+    public String getServerIp() {
+        return this.server.getServerIp();
+    }
+
+    @Override
     public void setStoreInfo(ServerInformation info) {
         this.storeInformation = info;
     }

--- a/fabric/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
+++ b/fabric/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
@@ -23,7 +23,7 @@ public class BanCommand extends SubCommand {
         String ip = context.getArgument("ip", String.class);
 
         if (!platform.isSetup()) {
-            source.sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key."), false);
+            source.sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key."), false);
             return;
         }
 

--- a/fabric/src/main/java/io/tebex/plugin/command/sub/CheckoutCommand.java
+++ b/fabric/src/main/java/io/tebex/plugin/command/sub/CheckoutCommand.java
@@ -21,7 +21,7 @@ public class CheckoutCommand extends SubCommand {
         TebexPlugin platform = getPlatform();
 
         if (!platform.isSetup()) {
-            context.getSource().sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key."), false);
+            context.getSource().sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key."), false);
             return;
         }
 

--- a/fabric/src/main/java/io/tebex/plugin/command/sub/InfoCommand.java
+++ b/fabric/src/main/java/io/tebex/plugin/command/sub/InfoCommand.java
@@ -28,7 +28,7 @@ public class InfoCommand extends SubCommand {
             source.sendFeedback(new LiteralText("§b[Tebex] §7Server prices are in " +  platform.getStoreInformation().getStore().getCurrency().getIso4217()), false);
             source.sendFeedback(new LiteralText("§b[Tebex] §7Webstore domain " +  platform.getStoreInformation().getStore().getDomain()), false);
         } else {
-            source.sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key."), false);
+            source.sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key."), false);
         }
     }
 

--- a/fabric/src/main/java/io/tebex/plugin/command/sub/LookupCommand.java
+++ b/fabric/src/main/java/io/tebex/plugin/command/sub/LookupCommand.java
@@ -20,7 +20,7 @@ public class LookupCommand extends SubCommand {
         TebexPlugin platform = getPlatform();
 
         if (!platform.isSetup()) {
-            source.sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key."), false);
+            source.sendFeedback(new LiteralText("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key."), false);
             return;
         }
 

--- a/fabric/src/main/java/io/tebex/plugin/command/sub/ReportCommand.java
+++ b/fabric/src/main/java/io/tebex/plugin/command/sub/ReportCommand.java
@@ -27,6 +27,7 @@ public class ReportCommand extends SubCommand {
         } else {
             context.getSource().sendFeedback(new LiteralText("§b[Tebex] §7Sending your report to Tebex..."), false);
             platform.sendTriageEvent(new Error("User reported error in-game: " + message));
+            context.getSource().sendFeedback(new LiteralText("§b[Tebex] §7Report sent successfully."), false);
         }
     }
 

--- a/sdk/src/main/java/io/tebex/sdk/SDK.java
+++ b/sdk/src/main/java/io/tebex/sdk/SDK.java
@@ -721,7 +721,7 @@ public class SDK {
             return null;
         }
 
-        return request("/lookup/" + username).withSecretKey(secretKey).sendAsync().thenApply(response -> {
+        return request("/user/" + username).withSecretKey(secretKey).sendAsync().thenApply(response -> {
             if(response.code() != 200 && response.code() != 404) {
                 CompletionException e = new CompletionException(new IOException("Unexpected status code (" + response.code() + ")"));
                 platform.sendTriageEvent(e);

--- a/sdk/src/main/java/io/tebex/sdk/platform/Platform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/Platform.java
@@ -172,9 +172,11 @@ public interface Platform {
         StringWriter traceWriter = new StringWriter();
         exception.printStackTrace(new PrintWriter(traceWriter));
 
-        TriageEvent.fromPlatform(this)
+        TriageEvent event = TriageEvent.fromPlatform(this)
                 .withErrorMessage(exception.getMessage())
-                .withTrace(traceWriter.toString()).send();
+                .withTrace(traceWriter.toString());
+
+        event.send();
     }
 
     default void handleOnlineCommands(QueuedPlayer player) {
@@ -426,4 +428,11 @@ public interface Platform {
      * @return The PlatformTelemetry instance.
      */
     PlatformTelemetry getTelemetry();
+
+    /**
+     * Gets the current server's IP address.
+     *
+     * @return IP address of the server as a string
+     */
+    String getServerIp();
 }

--- a/sdk/src/main/java/io/tebex/sdk/triage/TriageEvent.java
+++ b/sdk/src/main/java/io/tebex/sdk/triage/TriageEvent.java
@@ -1,6 +1,7 @@
 package io.tebex.sdk.triage;
 
 import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 import io.tebex.sdk.platform.Platform;
 import io.tebex.sdk.request.TebexRequest;
 import io.tebex.sdk.request.response.ServerInformation;
@@ -18,16 +19,23 @@ import java.util.concurrent.ExecutionException;
  *   of the error if applicable.
  */
 public class TriageEvent {
-    private final Platform _platform;
+    private transient final Platform _platform;
 
+    @SerializedName(value = "game_id")
     private String gameId;
+    @SerializedName(value = "framework_id")
     private String frameworkId;
+    @SerializedName(value = "plugin_version")
     private String pluginVersion;
+    @SerializedName(value = "server_ip")
     private String serverIp;
+    @SerializedName(value = "error_message")
     private String errorMessage;
     private String trace;
     private Map<String, String> metadata;
+    @SerializedName(value = "store_name")
     private String storeName;
+    @SerializedName(value = "store_url")
     private String storeUrl;
 
     private TriageEvent(Platform platform){
@@ -43,7 +51,10 @@ public class TriageEvent {
                 + " " + platform.getTelemetry().getJavaVersion();
         event.pluginVersion = platform.getTelemetry().getPluginVersion();
 
-        event.serverIp = ""; //TODO
+        event.serverIp = platform.getServerIp();
+        if (event.serverIp == null || event.serverIp.isEmpty()) {
+            event.serverIp = "0.0.0.0";
+        }
 
         // Assign store info if secret key is set
         if (platform.getSDK().getSecretKey() != null) {

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+
+# Tests all variants of the plugin
+
+# Test parameters
+TEBEX_TEST_SECRET_KEY="" # normal game server secret key to test setting secret
+
+# URLs to the JAR files we can download
+BUKKIT_JAR_URL='https://download.getbukkit.org/craftbukkit/craftbukkit-1.20.4.jar'
+BUNGEE_JAR_URL='https://ci.md-5.net/job/BungeeCord/lastSuccessfulBuild/artifact/bootstrap/target/BungeeCord.jar'
+SPIGOT_JAR_URL='https://download.getbukkit.org/spigot/spigot-1.20.4.jar'
+PAPER_JAR_URL='https://api.papermc.io/v2/projects/paper/versions/1.20.4/builds/381/downloads/paper-1.20.4-381.jar'
+PURPUR_JAR_URL='https://api.purpurmc.org/v2/purpur/1.20.4/latest/download'
+VELOCITY_JAR_URL='https://api.papermc.io/v2/projects/velocity/versions/3.3.0-SNAPSHOT/builds/316/downloads/velocity-3.3.0-SNAPSHOT-316.jar'
+
+# Record the start time
+SECONDS=0
+
+function downloadJar() {
+    local folder="$1"
+    local url="$2"
+    local filename="${url##*/}"
+
+    # Ensure the folder path is within the current working directory
+    if [[ "$folder" = /* || "$folder" = ../* ]]; then
+        echo "Error: The specified folder must be within the current working directory."
+        return 1
+    fi
+
+    # Check if the folder exists
+    if [[ -d "$folder" ]]; then
+        echo "Deleting existing folder: $folder"
+        #rm -rf "$folder"
+    fi
+
+    # Create the folder
+    mkdir -p "$folder"
+
+    # Download the file into the specified folder
+    echo "Downloading file to $folder/$filename"
+    wget -P "$folder" "$url"
+}
+
+function testCommands() {
+  local javaPid=$1
+  local pipe=$2
+  local command="/tebex help"
+}
+
+function testJar() {
+  local folder="$1"
+  local jarName="$2"
+
+  # Create a named pipe
+  local pipe="./command_pipe_$folder"
+  if [[ ! -p $pipe ]]; then
+      mkfifo $pipe
+  fi
+
+  echo "Testing .jar '$jarName' in '$folder'"
+  cd $folder
+  echo "eula=true" >> "eula.txt"
+
+  java -Xmx2G -jar "$jarName" nogui < $pipe &
+  javaPid=$!
+  echo "Waiting for server startup..."
+
+  mkdir -p "./logs/"
+  touch "./logs/latest.log"
+  tail -f "./logs/latest.log" | while read LINE; do
+      echo "$LINE" | grep "Welcome to Tebex" &> /dev/null
+      if [ $? -eq 0 ]; then
+          echo "> Tebex loaded successfully, terminating server process..."
+          testCommands $javaPid $pipe
+          sleep 2
+          kill $javaPid
+          break
+      fi
+  done
+
+  kill $javaPid
+  echo "Test completed."
+  cd ..
+}
+
+function installPluginToFolder() {
+  pluginType="$1" #ex. "bukkit", corresponding with type in build/libs: tebex-{pluginType}-2.0.0.jar
+  toFolder="$2" # root minecraft server folder containing /plugins
+
+  mkdir -p "$toFolder/plugins"
+  cp "../build/libs/tebex-$pluginType-2.0.0.jar" "$toFolder/plugins"
+}
+
+function copyWorlds() {
+  from="./$1"
+  to="./$2"
+
+  cp -r "$1/world" "$2/world"
+  cp -r "$1/world_nether" "$2/world_nether"
+  cp -r "$1/world_the_end" "$2/world_the_end"
+}
+# Initial setup
+rm -rf test
+mkdir test
+cd test
+
+# Test paper first as it's the fastest to generate the world. We'll copy the world to all other folders to prevent waiting
+# on world generation while testing.
+
+# Paper
+echo "Testing Paper..."
+downloadJar "paper" "$PAPER_JAR_URL"
+installPluginToFolder "bukkit" "./paper"
+testJar "paper" ${PAPER_JAR_URL##*/} # take filename from end of url
+
+# Bukkit
+#echo "Testing Bukkit..."
+#downloadJar "bukkit" "$BUKKIT_JAR_URL"
+#installPluginToFolder "bukkit" "./bukkit"
+#copyWorlds "paper" "bukkit"
+#testJar "bukkit" ${BUKKIT_JAR_URL##*/} # take filename from end of url
+
+# Bungee
+#echo "Testing BungeeCord..."
+#downloadJar "bungeecord" "$BUNGEE_JAR_URL"
+#installPluginToFolder "bungeecord" "./bungeecord"
+#testJar "bungeecord" ${BUNGEE_JAR_URL##*/} # take filename from end of url
+
+# Spigot
+#echo "Testing Spigot..."
+#downloadJar "spigot" "$SPIGOT_JAR_URL"
+#installPluginToFolder "bukkit" "./spigot"
+#copyWorlds "paper" "spigot"
+#testJar "spigot" ${SPIGOT_JAR_URL##*/} # take filename from end of url
+
+# Purpur
+#echo "Testing Purpur..."
+#downloadJar "purpur" "$PURPUR_JAR_URL"
+#installPluginToFolder "bukkit" "./purpur"
+#copyWorlds "paper" "spigot"
+#testJar "purpur" ${PURPUR_JAR_URL##*/} # take filename from end of url
+
+# Velocity
+#echo "Testing Velocity..."
+#downloadJar "velocity" "$VELOCITY_JAR_URL"
+#installPluginToFolder "velocity" "./velocity"
+#testJar "velocity" ${VELOCITY_JAR_URL##*/} # take filename from end of url
+
+elapsedTime=$SECONDS
+echo "Testing completed in $elapsedTime seconds"
+exit

--- a/velocity/src/main/java/io/tebex/plugin/TebexPlugin.java
+++ b/velocity/src/main/java/io/tebex/plugin/TebexPlugin.java
@@ -9,6 +9,8 @@ import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
 import com.velocitypowered.api.util.ProxyVersion;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import io.tebex.plugin.event.JoinListener;
@@ -27,6 +29,7 @@ import io.tebex.sdk.util.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -310,6 +313,16 @@ public class TebexPlugin implements Platform {
                 System.getProperty("os.arch"),
                 proxy.getConfiguration().isOnlineMode()
         );
+    }
+
+    @Override
+    public String getServerIp() {
+        Optional<RegisteredServer> firstListener = this.proxy.getAllServers().stream().findFirst();
+        if (firstListener.isPresent()) {
+            return firstListener.get().getServerInfo().getAddress().getAddress().getHostAddress();
+        }
+
+        return "0.0.0.0";
     }
 
     @Override

--- a/velocity/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
+++ b/velocity/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
@@ -21,7 +21,7 @@ public class BanCommand extends SubCommand {
         String ip = args[2];
 
         if (!platform.isSetup()) {
-            sender.sendMessage(Component.text("§b[Tebex] §7This server is not connected to a webstore. Use /tebex.secret to set your store key."));
+            sender.sendMessage(Component.text("§b[Tebex] §7This server is not connected to a webstore. Use /tebex secret to set your store key."));
             return;
         }
 


### PR DESCRIPTION
### Fixes
- Command usage instructions are now shown if incorrect/not enough args are used
- Store information was not properly reloaded after running `tebex secret`, causing errors until the server was restarted.
- `/tebex lookup` now uses the appropriate endpoint
- Some commands' usage instructions improperly included a `.` in the command name
- `/tebex report` now properly sends all report information to Tebex