### PR TITLE
Relocate Adventure to prevent conflicts with older Adventure APIs on the server

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -19,6 +19,7 @@ tasks.named("shadowJar", ShadowJar::class.java) {
 
     relocate("it.unimi", "io.tebex.plugin.libs.fastutil")
     relocate("okhttp3", "io.tebex.plugin.libs.okhttp3")
+    relocate("net.kyori", "io.tebex.plugin.libs.kyori")
     relocate("okio", "io.tebex.plugin.libs.okio")
     relocate("dev.dejvokep.boostedyaml", "io.tebex.plugin.libs.boostedyaml")
     relocate("org.jetbrains.annotations", "io.tebex.plugin.libs.jetbrains")


### PR DESCRIPTION
Some servers may have forks that contain older versions of Adventure in them. Relocating adventure prevents any possible issues with conflicting Adventure versions.