### PR TITLE
Relocate the `triumph-gui` lib on the Bukkit Module

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -26,6 +26,8 @@ tasks.named("shadowJar", ShadowJar::class.java) {
     relocate("kotlin", "io.tebex.plugin.libs.kotlin")
     relocate("com.github.benmanes.caffeine", "io.tebex.plugin.libs.caffeine")
     relocate("com.google.gson", "io.tebex.plugin.libs.gson")
+    relocate("dev.triumphteam.gui", "io.tebex.plugin.libs.triumphgui")
+
     minimize()
 }
 


### PR DESCRIPTION
The bukkit plugin generates exceptions and incompatibilities with other plugins that contain the `triumph-gui` library more or less up to date than the plugin due to significant changes in methods of the plugin, generating the following exception:
```
Caused by: java.lang.NoSuchMethodError: 'dev.triumphteam.gui.builder.gui.BaseGuiBuilder dev.triumphteam.gui.builder.gui.SimpleBuilder.title(net.kyori.adventure.text.Component)'
```
The proposed solution is to relocate to the `triumph-gui` package so that the plugin uses its own library with its own version instead of sharing it.
