### PR TITLE
fix(bukkit): old files deletion warning being emitted when it shouldn't

### DIFF
--- a/bukkit/src/main/java/io/tebex/plugin/TebexPlugin.java
+++ b/bukkit/src/main/java/io/tebex/plugin/TebexPlugin.java
@@ -201,7 +201,7 @@ public final class TebexPlugin extends JavaPlugin implements Platform {
             }
 
             boolean deletedLegacyPluginDir = FileUtils.deleteDirectory(oldPluginDir);
-            if(! deletedLegacyPluginDir || !deletedLegacyPluginJar) {
+            if(! deletedLegacyPluginDir && ! deletedLegacyPluginJar) {
                 warning("Failed to delete the old BuycraftX files. Please delete them manually in your /plugins folder to avoid conflicts.");
             }
         } catch (IOException e) {


### PR DESCRIPTION
Sometimes, we need to use the old configurations (referrals API) without downloading BuycraftX itself. This PR prevents the warning being shown if only one of the configuration directory or the plugin jar could not be deleted to limit user confusion. 

In our case, if the old BuycraftX plugin is present in the `plugins/` directory but not loaded, it is not likely it will be loaded on next startup and thus not likely to cause issues.