### PR TITLE
Relocate XSeries library

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -28,6 +28,7 @@ tasks.named("shadowJar", ShadowJar::class.java) {
     relocate("org.jetbrains.annotations", "io.tebex.plugin.libs.jetbrains")
     relocate("kotlin", "io.tebex.plugin.libs.kotlin")
     relocate("com.github.benmanes.caffeine", "io.tebex.plugin.libs.caffeine")
+    relocate("com.cryptomorin.xseries", "io.tebex.plugin.libs.xseries")
     minimize()
 }
 


### PR DESCRIPTION
#### Description:
The Bukkit plugin includes the [XSeries](https://github.com/CryptoMorin/XSeries) library to ensure compatibility with a wide range of Minecraft versions. To fix conflicts with other plugins, I have relocated XSeries within the Tebex plugin's JAR file.

#### Changes Made:
- The XSeries library has been relocated to `io.tebex.plugin.libs.xseries`.

#### Reasoning:
Relocating the library avoids compatibility issues that could arise when other plugins include a newer version of XSeries.

#### Impact:
- No functionality changes.
- Improved compatibility with other plugins.