### PR TITLE
Fix Important Fabric Vulnerability.

### DIFF
--- a/fabric-1.20.1/build.gradle.kts
+++ b/fabric-1.20.1/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:${fabricVersion}")
 
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
+    compileOnly("net.luckperms:api:5.4")
 }
 
 

--- a/fabric-1.20.1/src/main/resources/fabric.mod.json
+++ b/fabric-1.20.1/src/main/resources/fabric.mod.json
@@ -16,6 +16,7 @@
   "depends": {
     "fabricloader": ">=0.14.9",
     "fabric": "*",
-    "minecraft": ">=1.20"
+    "minecraft": ">=1.20",
+    "luckperms": "*"
   }
 }

--- a/fabric-1.20.4/build.gradle.kts
+++ b/fabric-1.20.4/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:${fabricVersion}")
 
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
+    compileOnly("net.luckperms:api:5.4")
 }
 
 

--- a/fabric-1.20.4/src/main/java/io/tebex/plugin/TebexPlugin.java
+++ b/fabric-1.20.4/src/main/java/io/tebex/plugin/TebexPlugin.java
@@ -19,8 +19,10 @@ import io.tebex.sdk.platform.config.ServerPlatformConfig;
 import io.tebex.sdk.request.response.ServerInformation;
 import io.tebex.sdk.util.CommandResult;
 import net.fabricmc.api.DedicatedServerModInitializer;
-import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -28,6 +30,7 @@ import net.minecraft.resource.featuretoggle.FeatureSet;
 import net.minecraft.screen.GenericContainerScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
@@ -50,6 +53,7 @@ public class TebexPlugin implements Platform, DedicatedServerModInitializer {
     private final String MOD_VERSION = "@VERSION@";
     private final File MOD_PATH = new File("./mods/" + MOD_ID);
     private MinecraftServer server;
+    private static LuckPerms luckPermsAPI;
 
     private SDK sdk;
     private ServerPlatformConfig config;
@@ -79,11 +83,12 @@ public class TebexPlugin implements Platform, DedicatedServerModInitializer {
 
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             this.server = server;
+            luckPermsAPI = LuckPermsProvider.get();
             onEnable();
         });
 
         // Initialise Managers.
-        CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> new CommandManager(this).register(dispatcher));
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> new CommandManager(this).register(dispatcher));
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> Multithreading.shutdown());
     }
@@ -347,5 +352,10 @@ public class TebexPlugin implements Platform, DedicatedServerModInitializer {
     @Override
     public void setStoreCategories(List<Category> categories) {
         this.storeCategories = categories;
+    }
+
+    public static boolean hasPermission(ServerCommandSource source, String permission) {
+        if (source.getPlayer() == null) return true;
+        return luckPermsAPI.getPlayerAdapter(ServerPlayerEntity.class).getPermissionData(source.getPlayer()).checkPermission(permission).asBoolean();
     }
 }

--- a/fabric-1.20.4/src/main/resources/fabric.mod.json
+++ b/fabric-1.20.4/src/main/resources/fabric.mod.json
@@ -16,6 +16,7 @@
   "depends": {
     "fabricloader": ">=0.14.9",
     "fabric": "*",
-    "minecraft": ">=1.20"
+    "minecraft": ">=1.20",
+    "luckperms": "*"
   }
 }

--- a/fabric-1.21.1/build.gradle.kts
+++ b/fabric-1.21.1/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:${fabricVersion}")
 
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
+    compileOnly("net.luckperms:api:5.4")
 }
 
 

--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/TebexPlugin.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/TebexPlugin.java
@@ -19,8 +19,10 @@ import io.tebex.sdk.platform.config.ServerPlatformConfig;
 import io.tebex.sdk.request.response.ServerInformation;
 import io.tebex.sdk.util.CommandResult;
 import net.fabricmc.api.DedicatedServerModInitializer;
-import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -28,6 +30,7 @@ import net.minecraft.resource.featuretoggle.FeatureSet;
 import net.minecraft.screen.GenericContainerScreenHandler;
 import net.minecraft.screen.ScreenHandlerType;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.collection.DefaultedList;
@@ -50,6 +53,7 @@ public class TebexPlugin implements Platform, DedicatedServerModInitializer {
     private final String MOD_VERSION = "@VERSION@";
     private final File MOD_PATH = new File("./mods/" + MOD_ID);
     private MinecraftServer server;
+    private static LuckPerms luckPermsAPI;
 
     private SDK sdk;
     private ServerPlatformConfig config;
@@ -79,11 +83,12 @@ public class TebexPlugin implements Platform, DedicatedServerModInitializer {
 
         ServerLifecycleEvents.SERVER_STARTED.register(server -> {
             this.server = server;
+            luckPermsAPI = LuckPermsProvider.get();
             onEnable();
         });
 
         // Initialise Managers.
-        CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> new CommandManager(this).register(dispatcher));
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> new CommandManager(this).register(dispatcher));
 
         ServerLifecycleEvents.SERVER_STOPPING.register(server -> Multithreading.shutdown());
     }
@@ -347,5 +352,10 @@ public class TebexPlugin implements Platform, DedicatedServerModInitializer {
     @Override
     public void setStoreCategories(List<Category> categories) {
         this.storeCategories = categories;
+    }
+
+    public static boolean hasPermission(ServerCommandSource source, String permission) {
+        if (source.getPlayer() == null) return true;
+        return luckPermsAPI.getPlayerAdapter(ServerPlayerEntity.class).getPermissionData(source.getPlayer()).checkPermission(permission).asBoolean();
     }
 }

--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/manager/CommandManager.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/manager/CommandManager.java
@@ -40,13 +40,15 @@ public class CommandManager {
     }
 
     public void register(CommandDispatcher<ServerCommandSource> dispatcher) {
-        LiteralArgumentBuilder<ServerCommandSource> baseCommand = literal("tebex").executes(context -> {
-            final ServerCommandSource source = context.getSource();
-            source.sendMessage(Text.of("§8[Tebex] §7Welcome to Tebex!"));
-            source.sendMessage(Text.of("§8[Tebex] §7This server is running version §fv" + platform.getVersion() + "§7."));
+        LiteralArgumentBuilder<ServerCommandSource> baseCommand = literal("tebex")
+                .requires(source -> TebexPlugin.hasPermission(source, "tebex.base"))
+                .executes(context -> {
+                    final ServerCommandSource source = context.getSource();
+                    source.sendMessage(Text.of("§8[Tebex] §7Welcome to Tebex!"));
+                    source.sendMessage(Text.of("§8[Tebex] §7This server is running version §fv" + platform.getVersion() + "§7."));
 
-            return 1;
-        });
+                    return 1;
+                });
 
         if (platform.getPlatformConfig().isBuyCommandEnabled()) {
             BuyCommand buyCommand = new BuyCommand(platform);
@@ -54,9 +56,10 @@ public class CommandManager {
         }
 
         commands.forEach(command -> {
-            LiteralArgumentBuilder<ServerCommandSource> subCommand = literal(command.getName());
+            LiteralArgumentBuilder<ServerCommandSource> subCommand = literal(command.getName())
+                    .requires(source -> TebexPlugin.hasPermission(source, command.getPermission()));
 
-            if(command.getName().equalsIgnoreCase("secret")) {
+            if (command.getName().equalsIgnoreCase("secret")) {
                 baseCommand.then(subCommand.then(argument("key", StringArgumentType.string()).executes(context -> {
                     command.execute(context);
                     return 1;
@@ -101,11 +104,11 @@ public class CommandManager {
             else if(command.getName().equalsIgnoreCase("sendlink")) {
                 baseCommand.then(subCommand
                         .then(argument("username", StringArgumentType.string())
-                        .then(argument("packageId", StringArgumentType.string()))
-                        .executes(context -> {
-                            command.execute(context);
-                            return 1;
-                        })));
+                                .then(argument("packageId", StringArgumentType.string()))
+                                .executes(context -> {
+                                    command.execute(context);
+                                    return 1;
+                                })));
             }
 
             else {

--- a/fabric-1.21.1/src/main/resources/fabric.mod.json
+++ b/fabric-1.21.1/src/main/resources/fabric.mod.json
@@ -16,6 +16,7 @@
   "depends": {
     "fabricloader": ">=0.14.9",
     "fabric": "*",
-    "minecraft": ">=1.20"
+    "minecraft": ">=1.20",
+    "luckperms": "*"
   }
 }


### PR DESCRIPTION
All fabric versions never actually set up permission requirements, so any player could run commands like `tebex secret` and change the server's secret. This was exploited: somebody changed a server's secret to a new one and started executing commands of their choice. This registers permissions correctly with brigadier and LuckPerms. I also updated CommandRegistrationCallback to v2. Tested, and live.