### PR TITLE
Fix the fabric-permissions-api versions for Fabric 1.21.1, 1.21.6, and 1.21.7

### DIFF
--- a/fabric-1.21.1/build.gradle.kts
+++ b/fabric-1.21.1/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
 
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
 
-    modImplementation("me.lucko:fabric-permissions-api:0.3.3")
-    include("me.lucko:fabric-permissions-api:0.3.3")
+    modImplementation("me.lucko:fabric-permissions-api:0.3.1")
+    include("me.lucko:fabric-permissions-api:0.3.1")
 }
 
 

--- a/fabric-1.21.6/build.gradle.kts
+++ b/fabric-1.21.6/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
 
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
 
-    modImplementation("me.lucko:fabric-permissions-api:0.3.3")
-    include("me.lucko:fabric-permissions-api:0.3.3")
+    modImplementation("me.lucko:fabric-permissions-api:0.4.0")
+    include("me.lucko:fabric-permissions-api:0.4.0")
 }
 
 

--- a/fabric-1.21.7/build.gradle.kts
+++ b/fabric-1.21.7/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
 
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
 
-    modImplementation("me.lucko:fabric-permissions-api:0.3.3")
-    include("me.lucko:fabric-permissions-api:0.3.3")
+    modImplementation("me.lucko:fabric-permissions-api:0.4.1")
+    include("me.lucko:fabric-permissions-api:0.4.1")
 }
 
 


### PR DESCRIPTION
Tested in Minecraft 1.21.1 with Fabric Launcher 0.16.14. Fixes #103.