### PR TITLE
resolve crash caused by permission check when running fabric 1.21.11

### DIFF
--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
@@ -14,6 +14,7 @@ import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
+import net.minecraft.command.DefaultPermissions;
 
 import java.util.Arrays;
 import java.util.UUID;
@@ -70,7 +71,13 @@ public class TebexCommandExecutor {
 
             // Final root: tebex -> subcommand -> args -> execute
             LiteralArgumentBuilder<ServerCommandSource> root = literal("tebex").requires(Permissions.require(command.getPermission(), false)
-                    .or(source -> source.hasPermissionLevel(4))).then(subCommand);
+                    .or(source -> {
+                        try {
+                            source.hasPermissionLevel(4);
+                        } catch (NoSuchMethodError e) {
+                            source.getPermissions().hasPermission(DefaultPermissions.OWNERS);
+                        }
+                            })).then(subCommand);
             dispatcher.register(root);
         });
     }


### PR DESCRIPTION
wrapped `source.hasPermissionLevel(4)` in a try-catch block to prevent crashes on 1.21.11 fabric servers, redirecting to the correct call `source.getPermissions().hasPermission(DefaultPermissions.OWNERS)`