### PR TITLE
Fix: OutOfBoundsException in Join Events & Proxy Leaks

### DIFF
--- a/bukkit/src/main/java/io/tebex/plugin/TebexBukkitPlugin.java
+++ b/bukkit/src/main/java/io/tebex/plugin/TebexBukkitPlugin.java
@@ -76,7 +76,10 @@ public final class TebexBukkitPlugin extends JavaPlugin {
         // clear server events every minute
         getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
             List<ServerEvent> allServerEvents = platform.getJoinEvents();
-            List<ServerEvent> runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
             if (runEvents.isEmpty()) return;
             if (!platform.isSetup()) return;
 

--- a/bukkit/src/main/java/io/tebex/plugin/event/PlayerJoinListener.java
+++ b/bukkit/src/main/java/io/tebex/plugin/event/PlayerJoinListener.java
@@ -18,6 +18,7 @@ public class PlayerJoinListener implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         Object playerId = platform.getPlayerId(player.getName(), player.getUniqueId());
+        platform.createJoinEvent(player.getUniqueId().toString(), player.getName(), player.getAddress().getAddress().getHostAddress());
 
         if(! platform.getQueuedPlayers().containsKey(playerId)) {
             return;

--- a/bukkit/src/main/java/io/tebex/plugin/gui/BuyGUI.java
+++ b/bukkit/src/main/java/io/tebex/plugin/gui/BuyGUI.java
@@ -20,11 +20,13 @@ import java.util.stream.Collectors;
 
 public class BuyGUI {
     private final BukkitPluginPlatform platform;
-    private final FileConfiguration config;
 
     public BuyGUI(BukkitPluginPlatform platform) {
         this.platform = platform;
-        this.config = platform.getPlugin().getConfig();
+    }
+
+    private FileConfiguration getConfig() {
+        return platform.getPlugin().getConfig();
     }
 
     public void open(Player player) {
@@ -35,8 +37,8 @@ public class BuyGUI {
         }
 
         ListingGui listingGui = new ListingGui()
-                .title(config.getString("gui.menu.home.title", "Server Shop"))
-                .rows(config.getInt("gui.menu.home.rows") < 1 ? categories.size() / 9 + 1 : config.getInt("gui.menu.home.rows"))
+                .title(getConfig().getString("gui.menu.home.title", "Server Shop"))
+                .rows(getConfig().getInt("gui.menu.home.rows") < 1 ? categories.size() / 9 + 1 : getConfig().getInt("gui.menu.home.rows"))
                 .create();
 
         categories.sort(Comparator.comparingInt(Category::getOrder));
@@ -52,7 +54,7 @@ public class BuyGUI {
     }
 
     private void openCategoryMenu(Player player, ICategory category) {
-        int configRows = config.getInt("gui.menu.category.rows");
+        int configRows = getConfig().getInt("gui.menu.category.rows");
         int neededRows = (category.getPackages().size() / 9) + 1;
 
         if (configRows < neededRows) {
@@ -60,7 +62,7 @@ public class BuyGUI {
         }
 
         ListingGui subListingGui = new ListingGui()
-                .title(config.getString("gui.menu.category.title").replace("%category%", category.getName()))
+                .title(getConfig().getString("gui.menu.category.title").replace("%category%", category.getName()))
                 .rows(configRows)
                 .create();
 
@@ -86,7 +88,7 @@ public class BuyGUI {
         } else if(category instanceof SubCategory) {
             SubCategory subCategory = (SubCategory) category;
 
-            subListingGui.updateTitle(config.getString("gui.menu.sub-category.title")
+            subListingGui.updateTitle(getConfig().getString("gui.menu.sub-category.title")
                     .replace("%category%", subCategory.getParent().getName())
                     .replace("%sub_category%", category.getName())
             );
@@ -118,7 +120,7 @@ public class BuyGUI {
     }
 
     private TebexItemBuilder getCategoryItemBuilder(ICategory category) {
-        ConfigurationSection section = config.getConfigurationSection("gui.item.category");
+        ConfigurationSection section = getConfig().getConfigurationSection("gui.item.category");
 
         String itemType = section.getString("material");
         Material defaultMaterial = MaterialUtil.fromString(itemType).isPresent() ? MaterialUtil.fromString(itemType).get().parseMaterial() : null;
@@ -134,7 +136,7 @@ public class BuyGUI {
     }
 
     private TebexItemBuilder getPackageItemBuilder(CategoryPackage categoryPackage) {
-        ConfigurationSection section = config.getConfigurationSection("gui.item." + (categoryPackage.hasSale() ? "package-sale" : "package"));
+        ConfigurationSection section = getConfig().getConfigurationSection("gui.item." + (categoryPackage.hasSale() ? "package-sale" : "package"));
 
         if(section == null) {
             platform.warning("Invalid configuration section for " + (categoryPackage.hasSale() ? "package-sale" : "package"), "Check that your definition for `" + categoryPackage.getName() + "` in config.yml is valid.");
@@ -170,7 +172,7 @@ public class BuyGUI {
     }
 
     private TebexItemBuilder getBackItemBuilder() {
-        ConfigurationSection section = config.getConfigurationSection("gui.item.back");
+        ConfigurationSection section = getConfig().getConfigurationSection("gui.item.back");
 
         String itemType = section.getString("material");
         Material defaultMaterial = MaterialUtil.fromString(itemType).isPresent() ? MaterialUtil.fromString(itemType).get().parseMaterial() : null;

--- a/bungeecord/src/main/java/io/tebex/plugin/JoinListener.java
+++ b/bungeecord/src/main/java/io/tebex/plugin/JoinListener.java
@@ -20,6 +20,7 @@ public class JoinListener implements Listener {
         String name = event.getConnection().getName();
 
         Object playerId = platform.getPlayerId(name, uuid);
+        platform.createJoinEvent(uuid.toString(), name, event.getConnection().getAddress().getAddress().getHostAddress());
 
         if (!platform.getQueuedPlayers().containsKey(playerId)) {
             return;

--- a/bungeecord/src/main/java/io/tebex/plugin/TebexBungeePlugin.java
+++ b/bungeecord/src/main/java/io/tebex/plugin/TebexBungeePlugin.java
@@ -1,7 +1,9 @@
 package io.tebex.plugin;
 
+import com.google.common.collect.Lists;
 import io.tebex.sdk.Tebex;
 import io.tebex.sdk.commands.TebexCommands;
+import io.tebex.sdk.obj.ServerEvent;
 import io.tebex.sdk.placeholder.PlaceholderManager;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
@@ -37,6 +39,27 @@ public class TebexBungeePlugin extends Plugin {
             platform.getSDK().getServerInformation().thenAccept(information -> platform.setStoreInfo(information));
             platform.getSDK().getListing().thenAccept(listing -> platform.setStoreCategories(listing));
         }, 0, 5, TimeUnit.MINUTES);
+
+        // Clear server events every minute
+        getProxy().getScheduler().schedule(this, () -> {
+            List<ServerEvent> allServerEvents = platform.getJoinEvents();
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
+            if (runEvents.isEmpty()) return;
+            if (!platform.isSetup()) return;
+
+            platform.getSDK().sendJoinEvents(runEvents)
+                    .thenAccept(aVoid -> {
+                        platform.clearSelectedPluginEvents(runEvents);
+                        platform.debug("Successfully sent join events.");
+                    })
+                    .exceptionally(throwable -> {
+                        platform.debug("Failed to send join events: " + throwable.getMessage());
+                        return null;
+                    });
+        }, 0, 1, TimeUnit.MINUTES);
     }
 
     private ProxiedPlayer getPlayer(Object player) {

--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/JoinListener.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/JoinListener.java
@@ -1,8 +1,6 @@
 package io.tebex.plugin;
 
 import io.tebex.sdk.obj.QueuedPlayer;
-import io.tebex.sdk.obj.ServerEvent;
-import io.tebex.sdk.obj.EnumServerEventType;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -16,7 +14,7 @@ public class JoinListener {
 
     private void onPlayerJoin(ServerPlayerEntity player) {
         Object playerId = plugin.getPlatform().getPlayerId(player.getName().getString(), player.getUuid());
-        plugin.getPlatform().getJoinEvents().add(new ServerEvent(player.getUuid().toString(), player.getName().getString(), player.getIp(), EnumServerEventType.JOIN));
+        plugin.getPlatform().createJoinEvent(player.getUuid().toString(), player.getName().getString(), player.getIp());
 
         if(! plugin.getPlatform().getQueuedPlayers().containsKey(playerId)) {
             return;
@@ -25,4 +23,3 @@ public class JoinListener {
         plugin.getPlatform().handleOnlineCommands(new QueuedPlayer(plugin.getPlatform().getQueuedPlayers().get(playerId), player.getName().getString(), player.getUuid().toString()));
     }
 }
-

--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
@@ -83,7 +83,10 @@ public class TebexFabricPlugin implements DedicatedServerModInitializer {
         // Clear server events each minute
         Multithreading.executeAsync(() -> {
             List<ServerEvent> allServerEvents = platform.getJoinEvents();
-            List<ServerEvent> runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
             if (runEvents.isEmpty()) return;
             if (!platform.isSetup()) return;
 

--- a/fabric-1.21.4/src/main/java/io/tebex/plugin/JoinListener.java
+++ b/fabric-1.21.4/src/main/java/io/tebex/plugin/JoinListener.java
@@ -1,8 +1,6 @@
 package io.tebex.plugin;
 
 import io.tebex.sdk.obj.QueuedPlayer;
-import io.tebex.sdk.obj.ServerEvent;
-import io.tebex.sdk.obj.EnumServerEventType;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -16,7 +14,7 @@ public class JoinListener {
 
     private void onPlayerJoin(ServerPlayerEntity player) {
         Object playerId = plugin.getPlatform().getPlayerId(player.getName().getString(), player.getUuid());
-        plugin.getPlatform().getJoinEvents().add(new ServerEvent(player.getUuid().toString(), player.getName().getString(), player.getIp(), EnumServerEventType.JOIN));
+        plugin.getPlatform().createJoinEvent(player.getUuid().toString(), player.getName().getString(), player.getIp());
 
         if(! plugin.getPlatform().getQueuedPlayers().containsKey(playerId)) {
             return;
@@ -25,4 +23,3 @@ public class JoinListener {
         plugin.getPlatform().handleOnlineCommands(new QueuedPlayer(plugin.getPlatform().getQueuedPlayers().get(playerId), player.getName().getString(), player.getUuid().toString()));
     }
 }
-

--- a/fabric-1.21.4/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
+++ b/fabric-1.21.4/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
@@ -83,7 +83,10 @@ public class TebexFabricPlugin implements DedicatedServerModInitializer {
         // Clear server events each minute
         Multithreading.executeAsync(() -> {
             List<ServerEvent> allServerEvents = platform.getJoinEvents();
-            List<ServerEvent> runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
             if (runEvents.isEmpty()) return;
             if (!platform.isSetup()) return;
 

--- a/fabric-1.21.5/src/main/java/io/tebex/plugin/JoinListener.java
+++ b/fabric-1.21.5/src/main/java/io/tebex/plugin/JoinListener.java
@@ -1,8 +1,6 @@
 package io.tebex.plugin;
 
 import io.tebex.sdk.obj.QueuedPlayer;
-import io.tebex.sdk.obj.ServerEvent;
-import io.tebex.sdk.obj.EnumServerEventType;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -16,7 +14,7 @@ public class JoinListener {
 
     private void onPlayerJoin(ServerPlayerEntity player) {
         Object playerId = plugin.getPlatform().getPlayerId(player.getName().getString(), player.getUuid());
-        plugin.getPlatform().getJoinEvents().add(new ServerEvent(player.getUuid().toString(), player.getName().getString(), player.getIp(), EnumServerEventType.JOIN));
+        plugin.getPlatform().createJoinEvent(player.getUuid().toString(), player.getName().getString(), player.getIp());
 
         if(! plugin.getPlatform().getQueuedPlayers().containsKey(playerId)) {
             return;
@@ -25,4 +23,3 @@ public class JoinListener {
         plugin.getPlatform().handleOnlineCommands(new QueuedPlayer(plugin.getPlatform().getQueuedPlayers().get(playerId), player.getName().getString(), player.getUuid().toString()));
     }
 }
-

--- a/fabric-1.21.5/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
+++ b/fabric-1.21.5/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
@@ -83,7 +83,10 @@ public class TebexFabricPlugin implements DedicatedServerModInitializer {
         // Clear server events each minute
         Multithreading.executeAsync(() -> {
             List<ServerEvent> allServerEvents = platform.getJoinEvents();
-            List<ServerEvent> runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
             if (runEvents.isEmpty()) return;
             if (!platform.isSetup()) return;
 

--- a/fabric-1.21.6/src/main/java/io/tebex/plugin/JoinListener.java
+++ b/fabric-1.21.6/src/main/java/io/tebex/plugin/JoinListener.java
@@ -1,8 +1,6 @@
 package io.tebex.plugin;
 
 import io.tebex.sdk.obj.QueuedPlayer;
-import io.tebex.sdk.obj.ServerEvent;
-import io.tebex.sdk.obj.EnumServerEventType;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -16,7 +14,7 @@ public class JoinListener {
 
     private void onPlayerJoin(ServerPlayerEntity player) {
         Object playerId = plugin.getPlatform().getPlayerId(player.getName().getString(), player.getUuid());
-        plugin.getPlatform().getJoinEvents().add(new ServerEvent(player.getUuid().toString(), player.getName().getString(), player.getIp(), EnumServerEventType.JOIN));
+        plugin.getPlatform().createJoinEvent(player.getUuid().toString(), player.getName().getString(), player.getIp());
 
         if(! plugin.getPlatform().getQueuedPlayers().containsKey(playerId)) {
             return;
@@ -25,4 +23,3 @@ public class JoinListener {
         plugin.getPlatform().handleOnlineCommands(new QueuedPlayer(plugin.getPlatform().getQueuedPlayers().get(playerId), player.getName().getString(), player.getUuid().toString()));
     }
 }
-

--- a/fabric-1.21.6/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
+++ b/fabric-1.21.6/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
@@ -83,7 +83,10 @@ public class TebexFabricPlugin implements DedicatedServerModInitializer {
         // Clear server events each minute
         Multithreading.executeAsync(() -> {
             List<ServerEvent> allServerEvents = platform.getJoinEvents();
-            List<ServerEvent> runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
             if (runEvents.isEmpty()) return;
             if (!platform.isSetup()) return;
 

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/JoinListener.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/JoinListener.java
@@ -1,8 +1,6 @@
 package io.tebex.plugin;
 
 import io.tebex.sdk.obj.QueuedPlayer;
-import io.tebex.sdk.obj.ServerEvent;
-import io.tebex.sdk.obj.EnumServerEventType;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.minecraft.server.network.ServerPlayerEntity;
 
@@ -16,7 +14,7 @@ public class JoinListener {
 
     private void onPlayerJoin(ServerPlayerEntity player) {
         Object playerId = plugin.getPlatform().getPlayerId(player.getName().getString(), player.getUuid());
-        plugin.getPlatform().getJoinEvents().add(new ServerEvent(player.getUuid().toString(), player.getName().getString(), player.getIp(), EnumServerEventType.JOIN));
+        plugin.getPlatform().createJoinEvent(player.getUuid().toString(), player.getName().getString(), player.getIp());
 
         if(! plugin.getPlatform().getQueuedPlayers().containsKey(playerId)) {
             return;
@@ -25,4 +23,3 @@ public class JoinListener {
         plugin.getPlatform().handleOnlineCommands(new QueuedPlayer(plugin.getPlatform().getQueuedPlayers().get(playerId), player.getName().getString(), player.getUuid().toString()));
     }
 }
-

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/TebexFabricPlugin.java
@@ -83,7 +83,10 @@ public class TebexFabricPlugin implements DedicatedServerModInitializer {
         // Clear server events each minute
         Multithreading.executeAsync(() -> {
             List<ServerEvent> allServerEvents = platform.getJoinEvents();
-            List<ServerEvent> runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
             if (runEvents.isEmpty()) return;
             if (!platform.isSetup()) return;
 

--- a/folia/src/main/java/io/tebex/plugin/TebexFoliaPlugin.java
+++ b/folia/src/main/java/io/tebex/plugin/TebexFoliaPlugin.java
@@ -76,7 +76,10 @@ public final class TebexFoliaPlugin extends JavaPlugin {
         // clear server events every minute
         getServer().getGlobalRegionScheduler().runAtFixedRate(this, task -> {
             List<ServerEvent> allServerEvents = platform.getJoinEvents();
-            List<ServerEvent> runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            List<ServerEvent> runEvents;
+            synchronized (allServerEvents) {
+                runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+            }
             if (runEvents.isEmpty()) return;
             if (!platform.isSetup()) return;
 

--- a/folia/src/main/java/io/tebex/plugin/event/PlayerJoinListener.java
+++ b/folia/src/main/java/io/tebex/plugin/event/PlayerJoinListener.java
@@ -2,8 +2,6 @@ package io.tebex.plugin.event;
 
 import io.tebex.plugin.FoliaPluginPlatform;
 import io.tebex.sdk.obj.QueuedPlayer;
-import io.tebex.sdk.obj.ServerEvent;
-import io.tebex.sdk.obj.EnumServerEventType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -20,7 +18,7 @@ public class PlayerJoinListener implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         Object playerId = platform.getPlayerId(player.getName(), player.getUniqueId());
-        platform.getJoinEvents().add(new ServerEvent(player.getUniqueId().toString(), player.getName(), player.getAddress().getAddress().getHostAddress(), EnumServerEventType.JOIN));
+        platform.createJoinEvent(player.getUniqueId().toString(), player.getName(), player.getAddress().getAddress().getHostAddress());
 
         if(! platform.getQueuedPlayers().containsKey(playerId)) {
             return;

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -40,7 +40,7 @@ public abstract class BasePluginPlatform implements PluginPlatform {
 
     protected ServerInformation storeInformation;
     protected List<Category> storeCategories = new ArrayList<>();
-    protected List<ServerEvent> serverEvents = new ArrayList<>();
+    protected List<ServerEvent> serverEvents = Collections.synchronizedList(new ArrayList<>());
 
     private final ArrayList<PluginEvent> PLUGIN_EVENTS = new ArrayList<>();
 
@@ -64,7 +64,7 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         placeholderManager = new PlaceholderManager();
         queuedPlayers = Maps.newConcurrentMap();
         storeCategories = new ArrayList<>();
-        serverEvents = new ArrayList<>();
+        serverEvents = Collections.synchronizedList(new ArrayList<>());
         placeholderManager.register(new UuidPlaceholder(placeholderManager));
 
         if (getPlatformConfig().getSecretKey() != null && !getPlatformConfig().getSecretKey().isEmpty()) {

--- a/velocity/src/main/java/io/tebex/plugin/TebexVelocityPlugin.java
+++ b/velocity/src/main/java/io/tebex/plugin/TebexVelocityPlugin.java
@@ -1,5 +1,6 @@
 package io.tebex.plugin;
 
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
@@ -11,6 +12,7 @@ import com.velocitypowered.api.util.ProxyVersion;
 import io.tebex.plugin.event.JoinListener;
 import io.tebex.plugin.manager.CommandManager;
 import io.tebex.sdk.Tebex;
+import io.tebex.sdk.obj.ServerEvent;
 import io.tebex.sdk.platform.BasePluginPlatform;
 import io.tebex.sdk.platform.PlatformTelemetry;
 import io.tebex.sdk.platform.PlatformType;
@@ -19,6 +21,7 @@ import net.kyori.adventure.text.Component;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -63,6 +66,30 @@ public class TebexVelocityPlugin extends BasePluginPlatform {
         new CommandManager(this).register();
         placeholderManager.registerDefaults();
         proxy.getEventManager().register(this, new JoinListener(this));
+
+        // Clear server events every minute
+        proxy.getScheduler()
+                .buildTask(this, () -> {
+                    List<ServerEvent> allServerEvents = getJoinEvents();
+                    List<ServerEvent> runEvents;
+                    synchronized (allServerEvents) {
+                        runEvents = Lists.newArrayList(allServerEvents.subList(0, Math.min(allServerEvents.size(), 750)));
+                    }
+                    if (runEvents.isEmpty()) return;
+                    if (!isSetup()) return;
+
+                    getSDK().sendJoinEvents(runEvents)
+                            .thenAccept(aVoid -> {
+                                clearSelectedPluginEvents(runEvents);
+                                debug("Successfully sent join events.");
+                            })
+                            .exceptionally(throwable -> {
+                                debug("Failed to send join events: " + throwable.getMessage());
+                                return null;
+                            });
+                })
+                .repeat(1, TimeUnit.MINUTES)
+                .schedule();
 
 //        proxy.getScheduler()
 //                .buildTask(this, () -> {

--- a/velocity/src/main/java/io/tebex/plugin/event/JoinListener.java
+++ b/velocity/src/main/java/io/tebex/plugin/event/JoinListener.java
@@ -18,6 +18,7 @@ public class JoinListener {
         Player player = event.getPlayer();
 
         Object playerId = plugin.getPlayerId(player.getUsername(), player.getUniqueId());
+        plugin.createJoinEvent(player.getUniqueId().toString(), player.getUsername(), player.getRemoteAddress().getAddress().getHostAddress());
 
         if (!plugin.getQueuedPlayers().containsKey(playerId)) {
             return;


### PR DESCRIPTION
There's currently a race condition issue in PlayerJoinEvent processing that caused the `ArrayIndexOutOfBoundsException` error referenced in Issue #111 on multi-threaded server platforms like Folia. While digging through this, it was also discovered that there is a potential memory leak related to server events not being cleared out on Velocity & BungeeCord.

### Main Changes
- Thread Safety: `serverEvents` in `BasePluginPlatform` is now a `Collections.synchronizedList`. This will ensure that player lists can be loaded correctly before they are accessed, this was the main cause for the PlayerJoinEvent issues on Folia.
- Safe Processing: The scheduled task that consumes `serverEvents` now syncronizes on the list before creating a `subList`, preventing crashes during any concurrent modifications.
- Bug Fix (Velocity & BungeeCord): Fixed a potential memory leak where the `serverEvents` variable was being appended but never processed or cleared correctly. I added the missing scheduled task to send & clear these events (This already exists on Bukkit).
- Refactoring: Updated `JoinListener` across all platforms to use `platform.createJoinEvent()` within the SDK and made sure to have consistent & thread-safe insertion.
