### PR TITLE
Fix: Permission Checking on Fabric 1.21.11

### DIFF
--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -140,6 +140,11 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
-        return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));
+        if (player == null) return false;
+        try {
+            return Permissions.check(player, permission, false) || player.hasPermissionLevel(4);
+        } catch (NoSuchMethodError e) {
+            return Permissions.check(player, permission, false);
+        }
     }
 }

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
@@ -70,7 +70,13 @@ public class TebexCommandExecutor {
 
             // Final root: tebex -> subcommand -> args -> execute
             LiteralArgumentBuilder<ServerCommandSource> root = literal("tebex").requires(Permissions.require(command.getPermission(), false)
-                    .or(source -> source.hasPermissionLevel(4))).then(subCommand);
+                    .or(source -> {
+                        try {
+                            return source.hasPermissionLevel(4);
+                        } catch (NoSuchMethodError e) {
+                            return Permissions.check(source, "tebex.admin", 4);
+                        }
+                    })).then(subCommand);
             dispatcher.register(root);
         });
     }

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
@@ -74,7 +74,7 @@ public class TebexCommandExecutor {
                         try {
                             return source.hasPermissionLevel(4);
                         } catch (NoSuchMethodError e) {
-                            return Permissions.check(source, "tebex.admin", 4);
+                            return platform.hasPermission(source.getName(), "tebex.admin");
                         }
                     })).then(subCommand);
             dispatcher.register(root);

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/command/TebexCommandExecutor.java
@@ -14,7 +14,6 @@ import me.lucko.fabric.api.permissions.v0.Permissions;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
-import net.minecraft.command.DefaultPermissions;
 
 import java.util.Arrays;
 import java.util.UUID;
@@ -71,13 +70,7 @@ public class TebexCommandExecutor {
 
             // Final root: tebex -> subcommand -> args -> execute
             LiteralArgumentBuilder<ServerCommandSource> root = literal("tebex").requires(Permissions.require(command.getPermission(), false)
-                    .or(source -> {
-                        try {
-                            source.hasPermissionLevel(4);
-                        } catch (NoSuchMethodError e) {
-                            source.getPermissions().hasPermission(DefaultPermissions.OWNERS);
-                        }
-                            })).then(subCommand);
+                    .or(source -> source.hasPermissionLevel(4))).then(subCommand);
             dispatcher.register(root);
         });
     }
@@ -85,7 +78,7 @@ public class TebexCommandExecutor {
     public void run(PlayerCommand command, com.mojang.brigadier.context.CommandContext<ServerCommandSource> context) {
         ServerCommandSource sender = context.getSource();
         String senderName = sender.getName();
-        UUID senderUUID = sender.getEntity() instanceof ServerPlayerEntity ? ((ServerPlayerEntity) sender.getEntity()).getUuid() : null;
+        UUID senderUUID = sender.getEntity() instanceof ServerPlayerEntity ? sender.getEntity().getUuid() : null;
         boolean isConsole = sender.getEntity() == null;
 
         String[] splitInput = context.getInput().split("\\s+");


### PR DESCRIPTION
A recent PR that was merged (#117) used unsupported methods for checking for permissions. This code changes it to use Fabric's own permissions API as a fallback if .hasPermissionLevel fails, preventing any plugin or server crashes. An unnecessary cast was also removed from `senderUUID` as it has already been casted on the same line.