### PR TITLE
Fix: Buy GUI showing regardless of Setup State

### DIFF
--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/command/BuyCommand.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/command/BuyCommand.java
@@ -16,6 +16,11 @@ public class BuyCommand {
     public int execute(CommandContext<ServerCommandSource> context) {
         final ServerCommandSource source = context.getSource();
 
+        if (!platform.isSetup()) {
+            source.sendMessage(Text.of("§cTebex is not setup yet!"));
+            return 1;
+        }
+
         try {
             ServerPlayerEntity player = source.getPlayer();
             new BuyGUI(platform).open(player);

--- a/fabric-1.21.4/src/main/java/io/tebex/plugin/command/BuyCommand.java
+++ b/fabric-1.21.4/src/main/java/io/tebex/plugin/command/BuyCommand.java
@@ -16,6 +16,11 @@ public class BuyCommand {
     public int execute(CommandContext<ServerCommandSource> context) {
         final ServerCommandSource source = context.getSource();
 
+        if (!platform.isSetup()) {
+            source.sendMessage(Text.of("§cTebex is not setup yet!"));
+            return 1;
+        }
+
         try {
             ServerPlayerEntity player = source.getPlayer();
             new BuyGUI(platform).open(player);

--- a/fabric-1.21.5/src/main/java/io/tebex/plugin/command/BuyCommand.java
+++ b/fabric-1.21.5/src/main/java/io/tebex/plugin/command/BuyCommand.java
@@ -16,6 +16,11 @@ public class BuyCommand {
     public int execute(CommandContext<ServerCommandSource> context) {
         final ServerCommandSource source = context.getSource();
 
+        if (!platform.isSetup()) {
+            source.sendMessage(Text.of("§cTebex is not setup yet!"));
+            return 1;
+        }
+
         try {
             ServerPlayerEntity player = source.getPlayer();
             new BuyGUI(platform).open(player);

--- a/fabric-1.21.6/src/main/java/io/tebex/plugin/command/BuyCommand.java
+++ b/fabric-1.21.6/src/main/java/io/tebex/plugin/command/BuyCommand.java
@@ -16,6 +16,11 @@ public class BuyCommand {
     public int execute(CommandContext<ServerCommandSource> context) {
         final ServerCommandSource source = context.getSource();
 
+        if (!platform.isSetup()) {
+            source.sendMessage(Text.of("§cTebex is not setup yet!"));
+            return 1;
+        }
+
         try {
             ServerPlayerEntity player = source.getPlayer();
             new BuyGUI(platform).open(player);

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/command/BuyCommand.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/command/BuyCommand.java
@@ -16,6 +16,11 @@ public class BuyCommand {
     public int execute(CommandContext<ServerCommandSource> context) {
         final ServerCommandSource source = context.getSource();
 
+        if (!platform.isSetup()) {
+            source.sendMessage(Text.of("§cTebex is not setup yet!"));
+            return 1;
+        }
+
         try {
             ServerPlayerEntity player = source.getPlayer();
             new BuyGUI(platform).open(player);


### PR DESCRIPTION
There is currently an issue with Fabric servers where the `/buy` command would show an empty Shop GUI regardless of the setup state of the plugin or not. This PR fixes that issue, and ensures that the GUI does not appear until `tebex secret {token}` has been run and/or the store has been connected.