### PR TITLE
Refactor command queue handling to prevent duplicate execution on Folia. Introduced atomic flag to track command check progress and updated comments for clarity.

### DIFF
--- a/folia/src/main/java/io/tebex/plugin/TebexFoliaPlugin.java
+++ b/folia/src/main/java/io/tebex/plugin/TebexFoliaPlugin.java
@@ -94,8 +94,9 @@ public final class TebexFoliaPlugin extends JavaPlugin {
                     });
         }, 1, 60 * 20);
 
-        // start the initial check, which is rescheduled according to the next_check from remote
-        platform.checkCommandQueue(true);
+        // Initial check is started by initStore() when getServerInformation() completes (see BasePluginPlatform).
+        // Do not call checkCommandQueue here to avoid running it twice on Folia (once from here and once from
+        // initStore's callback), which would process online players' commands twice.
     }
 
     /**

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -20,6 +20,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
 import static io.tebex.sdk.util.ResourceUtil.getBundledFile;
@@ -43,6 +44,7 @@ public abstract class BasePluginPlatform implements PluginPlatform {
     protected List<ServerEvent> serverEvents = Collections.synchronizedList(new ArrayList<>());
 
     private final ArrayList<PluginEvent> PLUGIN_EVENTS = new ArrayList<>();
+    private final AtomicBoolean commandCheckInProgress = new AtomicBoolean(false);
 
     /**
      * Checks if the configured store is Geyser/Offline
@@ -113,10 +115,19 @@ public abstract class BasePluginPlatform implements PluginPlatform {
             return forceCheckOutput;
         }
 
+        if (!commandCheckInProgress.compareAndSet(false, true)) {
+            debug("Command queue check already in progress. Skipping to avoid duplicate execution.");
+            if (useRemoteNextCheck) {
+                executeAsyncLater(this::performCheck, 60, TimeUnit.SECONDS);
+            }
+            return forceCheckOutput;
+        }
+
         debug("Checking for due players...");
         getQueuedPlayers().clear();
 
         getSDK().getDuePlayers().whenComplete((duePlayersResponse, ex) -> {
+            try {
             ArrayList<String> output = new ArrayList<>();
             if (ex != null) {
                 if (ex.getMessage().contains("429")) { // handling for rate limits
@@ -156,6 +167,9 @@ public abstract class BasePluginPlatform implements PluginPlatform {
 
             if(! duePlayersResponse.isExecuteOffline()) return;
             handleOfflineCommands();
+            } finally {
+                commandCheckInProgress.set(false);
+            }
         });
 
         return forceCheckOutput;


### PR DESCRIPTION
## Summary

This PR fixes an issue on **Folia** where purchase commands could be executed **twice** when the player is **online**. The root cause was a redundant call to `checkCommandQueue(true)` during Folia plugin enable, combined with missing protection against overlapping command-queue checks.

In favour of https://github.com/tebexio/Tebex-Minecraft/issues/125

## Changes

### 1) Folia: remove redundant command queue check on startup

**File:** `folia/src/main/java/io/tebex/plugin/TebexFoliaPlugin.java`

* Removed the `platform.checkCommandQueue(true)` call at the end of `onEnable()`.
* The initial queue check is now triggered **only** from `initStore()` after `getServerInformation()` succeeds, matching the existing Bukkit behavior (where the `onEnable()` call is commented out).
* Added a code comment explaining why `checkCommandQueue` should not be invoked from `onEnable()` on Folia.

**Why:**
On Folia, `onEnable()` could initiate a queue check concurrently with the store initialization flow, resulting in duplicate processing and command execution.

---

### 2) SDK: guard against concurrent command queue checks

**File:** `sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java`

* Introduced `AtomicBoolean commandCheckInProgress` to prevent parallel executions of `checkCommandQueue()`.
* At the beginning of `checkCommandQueue()`:

  * If a run is already active (`compareAndSet(false, true)` fails), the check is skipped.
  * If appropriate, the next check is still scheduled in **60 seconds**.
* In the `whenComplete` callback of `getDuePlayers()`:

  * Wrapped the entire callback logic in a `try/finally`.
  * In `finally`, `commandCheckInProgress.set(false)` ensures the next run is allowed.

**Why:**
Even with the Folia startup fix, overlapping checks can still occur (e.g., scheduler timings, network delays, async completions). This guard ensures command processing remains idempotent with respect to scheduling and avoids double execution due to concurrency.

## Result

* Commands are no longer executed twice on Folia when the player is online.
* `checkCommandQueue()` is protected from overlapping runs across all platforms.

## Testing

* Verified on Folia `1.21.11` that:

  * Purchases made while the player is **online** execute commands **once**.
  * Purchases made while the player is **offline** execute commands **once**.
* Verified both purchase flows:

  1. Tebex store purchase
  2. Manual payment creation