### PR TITLE
Fix: Fabric Telemetry not using Correct Methods

### DIFF
--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -120,13 +120,9 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
-        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
-                .map(container -> container.getMetadata().getVersion().getFriendlyString())
-                .orElse("Unknown");
-
         return new PlatformTelemetry(
                 getPluginVersion(),
-                "Fabric " + fabricVersion,
+                plugin.getPlatform().getType().toString(),
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -7,6 +7,7 @@ import io.tebex.sdk.platform.PlatformType;
 import io.tebex.sdk.platform.config.ServerPlatformConfig;
 import io.tebex.sdk.util.CommandResult;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -119,9 +120,13 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
+        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("Unknown");
+
         return new PlatformTelemetry(
                 getPluginVersion(),
-                server.getName(),
+                "Fabric " + fabricVersion,
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -120,13 +120,9 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
-        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
-                .map(container -> container.getMetadata().getVersion().getFriendlyString())
-                .orElse("Unknown");
-
         return new PlatformTelemetry(
                 getPluginVersion(),
-                "Fabric " + fabricVersion,
+                plugin.getPlatform().getType().toString(),
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -7,6 +7,7 @@ import io.tebex.sdk.platform.PlatformType;
 import io.tebex.sdk.platform.config.ServerPlatformConfig;
 import io.tebex.sdk.util.CommandResult;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -119,9 +120,13 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
+        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("Unknown");
+
         return new PlatformTelemetry(
                 getPluginVersion(),
-                server.getName(),
+                "Fabric " + fabricVersion,
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -120,13 +120,9 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
-        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
-                .map(container -> container.getMetadata().getVersion().getFriendlyString())
-                .orElse("Unknown");
-
         return new PlatformTelemetry(
                 getPluginVersion(),
-                "Fabric " + fabricVersion,
+                plugin.getPlatform().getType().toString(),
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -7,6 +7,7 @@ import io.tebex.sdk.platform.PlatformType;
 import io.tebex.sdk.platform.config.ServerPlatformConfig;
 import io.tebex.sdk.util.CommandResult;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -119,9 +120,13 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
+        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("Unknown");
+
         return new PlatformTelemetry(
                 getPluginVersion(),
-                server.getName(),
+                "Fabric " + fabricVersion,
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -120,13 +120,9 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
-        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
-                .map(container -> container.getMetadata().getVersion().getFriendlyString())
-                .orElse("Unknown");
-
         return new PlatformTelemetry(
                 getPluginVersion(),
-                "Fabric " + fabricVersion,
+                plugin.getPlatform().getType().toString(),
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -7,6 +7,7 @@ import io.tebex.sdk.platform.PlatformType;
 import io.tebex.sdk.platform.config.ServerPlatformConfig;
 import io.tebex.sdk.util.CommandResult;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -119,9 +120,13 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
+        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("Unknown");
+
         return new PlatformTelemetry(
                 getPluginVersion(),
-                server.getName(),
+                "Fabric " + fabricVersion,
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -120,13 +120,9 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
-        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
-                .map(container -> container.getMetadata().getVersion().getFriendlyString())
-                .orElse("Unknown");
-
         return new PlatformTelemetry(
                 getPluginVersion(),
-                "Fabric " + fabricVersion,
+                plugin.getPlatform().getType().toString(),
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -7,6 +7,7 @@ import io.tebex.sdk.platform.PlatformType;
 import io.tebex.sdk.platform.config.ServerPlatformConfig;
 import io.tebex.sdk.util.CommandResult;
 import me.lucko.fabric.api.permissions.v0.Permissions;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -119,9 +120,13 @@ public class FabricPluginPlatform extends BasePluginPlatform {
             serverVersion = matcher.group(1);
         }
 
+        String fabricVersion = FabricLoader.getInstance().getModContainer("fabricloader")
+                .map(container -> container.getMetadata().getVersion().getFriendlyString())
+                .orElse("Unknown");
+
         return new PlatformTelemetry(
                 getPluginVersion(),
-                server.getName(),
+                "Fabric " + fabricVersion,
                 serverVersion,
                 System.getProperty("java.version"),
                 System.getProperty("os.arch"),


### PR DESCRIPTION
`server.getName()` returns "Server" on Fabric, and this has been causing some confusion with analytics. This PR switches it out to use `plugin.getPlatform().getType().toString()` on all Telemetry calls. There is currently some mix and match between the SDK and the Fabric platforms, long-term it should be using the SDK but this is a temporary fix for right now until the SDK gets fully implemented.