### PR TITLE
Fix: UUID Matching not working for Offline Players

### DIFF
--- a/sdk/src/main/java/io/tebex/sdk/obj/QueuedCommand.java
+++ b/sdk/src/main/java/io/tebex/sdk/obj/QueuedCommand.java
@@ -1,5 +1,6 @@
 package io.tebex.sdk.obj;
 
+import io.tebex.sdk.util.UUIDUtil;
 import lombok.Data;
 
 @Data
@@ -20,14 +21,25 @@ public class QueuedCommand {
             parsedCommand = parsedCommand.replace("{username}", player.getName());
             parsedCommand = parsedCommand.replace("{name}", player.getName());
 
-            if (player.getUuid() != null) { // offline servers will return null uuid here as these uuids are not verified
+            if (isMissingUuid(player.getUuid())) {
+                // Offline/unauthenticated players: fall back to username for both placeholders
+                parsedCommand = parsedCommand.replace("{id}", player.getName());
+                parsedCommand = parsedCommand.replace("{uuid}", player.getName());
+            } else {
                 parsedCommand = parsedCommand.replace("{id}", player.getUuid());
                 parsedCommand = parsedCommand.replace("{uuid}", player.getUuid());
-            } else { // {id} must still be replaced with username if uuid is not present
-                parsedCommand = parsedCommand.replace("{id}", player.getName());
             }
         }
 
         return parsedCommand;
+    }
+
+    private boolean isMissingUuid(String uuid) {
+        if (uuid == null) return true;
+
+        String trimmed = uuid.trim();
+        return trimmed.isEmpty()
+                || trimmed.equalsIgnoreCase("null")
+                || trimmed.equalsIgnoreCase(UUIDUtil.EMPTY_UUID.toString());
     }
 }

--- a/sdk/src/test/java/io/tebex/sdk/obj/QueuedCommandTest.java
+++ b/sdk/src/test/java/io/tebex/sdk/obj/QueuedCommandTest.java
@@ -1,0 +1,68 @@
+package io.tebex.sdk.obj;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class QueuedCommandTest {
+
+    @Test
+    void offlinePlayersFallbackToNameForIdAndUuid() {
+        QueuedPlayer offlinePlayer = new QueuedPlayer(1, "Notch", null);
+        QueuedCommand command = new QueuedCommand(
+                10,
+                "say {username} {id} {uuid}",
+                0,
+                0,
+                0,
+                0,
+                offlinePlayer,
+                false
+        );
+
+        String parsed = command.getParsedCommand();
+
+        assertEquals("say Notch Notch Notch", parsed);
+        assertFalse(parsed.contains("00000000-0000-0000-0000-000000000000"));
+    }
+
+    @Test
+    void stringNullUuidAlsoFallsBackToName() {
+        QueuedPlayer offlinePlayer = new QueuedPlayer(2, "Alex", "null");
+        QueuedCommand command = new QueuedCommand(
+                11,
+                "grant {id} {uuid}",
+                0,
+                0,
+                0,
+                0,
+                offlinePlayer,
+                false
+        );
+
+        String parsed = command.getParsedCommand();
+
+        assertEquals("grant Alex Alex", parsed);
+    }
+
+    @Test
+    void onlinePlayersKeepUuid() {
+        String rawMojangUuid = "123456781234123412341234567890ab";
+        QueuedPlayer onlinePlayer = new QueuedPlayer(3, "Steve", rawMojangUuid);
+        QueuedCommand command = new QueuedCommand(
+                12,
+                "lp user {id} parent add default",
+                0,
+                0,
+                0,
+                0,
+                onlinePlayer,
+                true
+        );
+
+        String parsed = command.getParsedCommand();
+
+        assertEquals("lp user 12345678-1234-1234-1234-1234567890ab parent add default", parsed);
+    }
+}


### PR DESCRIPTION
An issue was reported with resolving offline players in #113 on Bukkit servers, to where the server would assign a null UUID instead of the player's in-game name on offline-servers. This PR fixes this by "falling back" to the player's store name that was used when making a purchase.