### PR TITLE
Fix: UUID Casting for Online Player Names

### DIFF
--- a/bukkit/src/main/java/io/tebex/plugin/BukkitPluginPlatform.java
+++ b/bukkit/src/main/java/io/tebex/plugin/BukkitPluginPlatform.java
@@ -95,13 +95,17 @@ public class BukkitPluginPlatform extends BasePluginPlatform {
 
     @Override
     public <T> T getPlayer(Object uuidOrUsername) {
-        if(uuidOrUsername == null) return null;
+        if (uuidOrUsername == null) return null;
 
-        if (isOnlineMode() && !isGeyser() && uuidOrUsername instanceof UUID) {
+        if (uuidOrUsername instanceof UUID) {
             return (T) Bukkit.getServer().getPlayer((UUID) uuidOrUsername);
         }
 
-        return (T) Bukkit.getServer().getPlayerExact((String) uuidOrUsername);
+        if (uuidOrUsername instanceof String) {
+            return (T) Bukkit.getServer().getPlayerExact((String) uuidOrUsername);
+        }
+
+        return null;
     }
 
     @Override

--- a/folia/src/main/java/io/tebex/plugin/FoliaPluginPlatform.java
+++ b/folia/src/main/java/io/tebex/plugin/FoliaPluginPlatform.java
@@ -95,13 +95,17 @@ public class FoliaPluginPlatform extends BasePluginPlatform {
 
     @Override
     public <T> T getPlayer(Object uuidOrUsername) {
-        if(uuidOrUsername == null) return null;
+        if (uuidOrUsername == null) return null;
 
-        if (isOnlineMode() && !isGeyser() && uuidOrUsername instanceof UUID) {
+        if (uuidOrUsername instanceof UUID) {
             return (T) Bukkit.getServer().getPlayer((UUID) uuidOrUsername);
         }
 
-        return (T) Bukkit.getServer().getPlayerExact((String) uuidOrUsername);
+        if (uuidOrUsername instanceof String) {
+            return (T) Bukkit.getServer().getPlayerExact((String) uuidOrUsername);
+        }
+
+        return null;
     }
 
     @Override

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -194,13 +194,13 @@ public abstract class BasePluginPlatform implements PluginPlatform {
      */
     @NotNull
     public final Object getPlayerId(String name, UUID uuid) {
-        // online mode uses uuids while offline mode uses usernames. public final to the name if we ever fail to have an uuid
-        Object identifier = isOnlineMode() ? uuid : name;
-        if (identifier == null) {
-            identifier = (name == null) ? "" : name;
+        // Geyser/offline stores and missing UUIDs must use usernames for consistent matching.
+        boolean useUuid = isOnlineMode() && !isGeyser() && uuid != null && !UUIDUtil.EMPTY_UUID.equals(uuid);
+        if (useUuid) {
+            return uuid;
         }
 
-        return identifier;
+        return (name == null) ? "" : name;
     }
 
     /**


### PR DESCRIPTION
There was an issue where player names were being casted as UUIDs in certain scenarios in the latest version of the plugin. This PR works to resolve that issue going forward. The stacktrace is posted below.

Failed to handle online commands for player '{playerName}': class java.util.UUID cannot be cast to class java.lang.String (java.util.UUID and java.lang.String are in module java.base of loader 'bootstrap')

java.lang.ClassCastException: class java.util.UUID cannot be cast to class java.lang.String (java.util.UUID and java.lang.String are in module java.base of loader 'bootstrap') at tebex-bukkit-2.3.2-04452e4.jar//io.tebex.plugin.BukkitPluginPlatform.getPlayer(BukkitPluginPlatform.java:104) at tebex-bukkit-2.3.2-04452e4.jar//io.tebex.sdk.platform.PluginPlatform.isPlayerOnline(PluginPlatform.java:127) at tebex-bukkit-2.3.2-04452e4.jar//io.tebex.sdk.platform.BasePluginPlatform.handleOnlineCommands(BasePluginPlatform.java:169) at tebex-bukkit-2.3.2-04452e4.jar//io.tebex.sdk.platform.BasePluginPlatform.lambda$checkCommandQueue$2(BasePluginPlatform.java:150) at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863) at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841) at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510) at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2179) at tebex-bukkit-2.3.2-04452e4.jar//io.tebex.sdk.request.TebexRequest$1.onResponse(TebexRequest.java:142) at tebex-bukkit-2.3.2-04452e4.jar//io.tebex.plugin.libs.okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519) at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) at java.base/java.lang.Thread.run(Thread.java:1583)
