### PR TITLE
Fix: UUID Swapping for Offline Players

### DIFF
--- a/sdk/src/main/java/io/tebex/sdk/placeholder/defaults/UuidPlaceholder.java
+++ b/sdk/src/main/java/io/tebex/sdk/placeholder/defaults/UuidPlaceholder.java
@@ -17,8 +17,8 @@ public class UuidPlaceholder implements Placeholder {
     @Override
     public String handle(QueuedPlayer player, String command) {
         if (player.getUuid() == null || player.getUuid().equals("null") || player.getUuid().equals(EMPTY_UUID.toString())) {
-            return placeholderManager.getUsernameRegex().matcher(command).replaceAll(player.getName());
+            return placeholderManager.getUniqueIdRegex().matcher(command).replaceAll(player.getName());
         }
-        return placeholderManager.getUsernameRegex().matcher(command).replaceAll(UUIDUtil.mojangIdToJavaId(player.getUuid()).toString());
+        return placeholderManager.getUniqueIdRegex().matcher(command).replaceAll(UUIDUtil.mojangIdToJavaId(player.getUuid()).toString());
     }
 }

--- a/sdk/src/test/java/io/tebex/sdk/placeholder/defaults/UuidPlaceholderTest.java
+++ b/sdk/src/test/java/io/tebex/sdk/placeholder/defaults/UuidPlaceholderTest.java
@@ -1,0 +1,35 @@
+package io.tebex.sdk.placeholder.defaults;
+
+import io.tebex.sdk.obj.QueuedPlayer;
+import io.tebex.sdk.placeholder.PlaceholderManager;
+import io.tebex.sdk.util.UUIDUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UuidPlaceholderTest {
+
+    @Test
+    void onlyReplacesIdAndUuidWhenUuidMissing() {
+        PlaceholderManager placeholderManager = new PlaceholderManager();
+        UuidPlaceholder placeholder = new UuidPlaceholder(placeholderManager);
+        QueuedPlayer player = new QueuedPlayer(1, "Notch", null);
+
+        String parsed = placeholder.handle(player, "cmd {username} {name} {player} {id} {uuid}");
+
+        assertEquals("cmd {username} {name} {player} Notch Notch", parsed);
+    }
+
+    @Test
+    void onlyReplacesIdAndUuidWhenUuidPresent() {
+        PlaceholderManager placeholderManager = new PlaceholderManager();
+        UuidPlaceholder placeholder = new UuidPlaceholder(placeholderManager);
+        String mojangUuid = "123456781234123412341234567890ab";
+        QueuedPlayer player = new QueuedPlayer(2, "Steve", mojangUuid);
+
+        String parsed = placeholder.handle(player, "cmd {username} {name} {player} {id} {uuid}");
+
+        String javaUuid = UUIDUtil.mojangIdToJavaId(mojangUuid).toString();
+        assertEquals("cmd {username} {name} {player} " + javaUuid + " " + javaUuid, parsed);
+    }
+}


### PR DESCRIPTION
This PR introduces the fix as suggested in #132. A test class was also written for local parsing & testing.
This was tested across all supported Minecraft versions with no noticeable breakages.