### PR TITLE
Modify class name

### DIFF
--- a/bungeecord/src/main/resources/bungee.yml
+++ b/bungeecord/src/main/resources/bungee.yml
@@ -1,3 +1,3 @@
 name: Tebex
 version: '${version}'
-main: io.tebex.plugin.TebexPlugin
+main: io.tebex.plugin.TebexBungeePlugin


### PR DESCRIPTION
At some point main class name has been modified. This makes impossible to load the plugin