### PR TITLE
feat: Geyser Support using Floodgate API

### DIFF
--- a/bukkit/src/main/java/io/tebex/plugin/BukkitPluginPlatform.java
+++ b/bukkit/src/main/java/io/tebex/plugin/BukkitPluginPlatform.java
@@ -146,12 +146,6 @@ public class BukkitPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        Player player = getPlayer(playerName);
-        return player == null ? null : player.getUniqueId();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         Player player = getPlayer(username);
         return player != null && player.hasPermission(permission);

--- a/bukkit/src/main/java/io/tebex/plugin/BukkitPluginPlatform.java
+++ b/bukkit/src/main/java/io/tebex/plugin/BukkitPluginPlatform.java
@@ -146,6 +146,12 @@ public class BukkitPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        Player player = getPlayer(playerName);
+        return player == null ? null : player.getUniqueId();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         Player player = getPlayer(username);
         return player != null && player.hasPermission(permission);

--- a/bukkit/src/main/java/io/tebex/plugin/gui/BuyGUI.java
+++ b/bukkit/src/main/java/io/tebex/plugin/gui/BuyGUI.java
@@ -113,7 +113,7 @@ public class BuyGUI {
                     // Create Checkout Url
                     platform.getSDK().createCheckoutUrl(categoryPackage.getId(), player.getName())
                             .thenAccept(checkout -> {
-                                player.sendMessage(ChatColor.GREEN + "You can checkout here: " + checkout.getUrl());
+                                platform.sendCheckoutLink(player.getName(), checkout.getUrl());
                             }).exceptionally(ex -> {
                                 player.sendMessage(ChatColor.RED
                                         + "Failed to create checkout URL. Please contact an administrator.");

--- a/bungeecord/src/main/java/io/tebex/plugin/BungeePluginPlatform.java
+++ b/bungeecord/src/main/java/io/tebex/plugin/BungeePluginPlatform.java
@@ -125,12 +125,6 @@ public class BungeePluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        ProxiedPlayer player = getPlayer(playerName);
-        return player == null ? null : player.getUniqueId();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         ProxiedPlayer player = getPlayer(username);
         return player != null && player.hasPermission(permission);

--- a/bungeecord/src/main/java/io/tebex/plugin/BungeePluginPlatform.java
+++ b/bungeecord/src/main/java/io/tebex/plugin/BungeePluginPlatform.java
@@ -125,6 +125,12 @@ public class BungeePluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        ProxiedPlayer player = getPlayer(playerName);
+        return player == null ? null : player.getUniqueId();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         ProxiedPlayer player = getPlayer(username);
         return player != null && player.hasPermission(permission);

--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,6 +139,12 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        ServerPlayerEntity player = getPlayer(playerName);
+        return player == null ? null : player.getUuid();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.1/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,12 +139,6 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        ServerPlayerEntity player = getPlayer(playerName);
-        return player == null ? null : player.getUuid();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.11/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.11/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -140,6 +140,12 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        ServerPlayerEntity player = getPlayer(playerName);
+        return player == null ? null : player.getUuid();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         if (player == null) return false;

--- a/fabric-1.21.11/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.11/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -140,12 +140,6 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        ServerPlayerEntity player = getPlayer(playerName);
-        return player == null ? null : player.getUuid();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         if (player == null) return false;

--- a/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,6 +139,12 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        ServerPlayerEntity player = getPlayer(playerName);
+        return player == null ? null : player.getUuid();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.4/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,12 +139,6 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        ServerPlayerEntity player = getPlayer(playerName);
-        return player == null ? null : player.getUuid();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,6 +139,12 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        ServerPlayerEntity player = getPlayer(playerName);
+        return player == null ? null : player.getUuid();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.5/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,12 +139,6 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        ServerPlayerEntity player = getPlayer(playerName);
-        return player == null ? null : player.getUuid();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,6 +139,12 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        ServerPlayerEntity player = getPlayer(playerName);
+        return player == null ? null : player.getUuid();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.6/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,12 +139,6 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        ServerPlayerEntity player = getPlayer(playerName);
-        return player == null ? null : player.getUuid();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         return player != null && (Permissions.check(player, permission, false) || player.hasPermissionLevel(4));

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,6 +139,12 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        ServerPlayerEntity player = getPlayer(playerName);
+        return player == null ? null : player.getUuid();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         if (player == null) return false;

--- a/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
+++ b/fabric-1.21.7/src/main/java/io/tebex/plugin/FabricPluginPlatform.java
@@ -139,12 +139,6 @@ public class FabricPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        ServerPlayerEntity player = getPlayer(playerName);
-        return player == null ? null : player.getUuid();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         ServerPlayerEntity player = getPlayer(username); //ops override permissions in case no manager is used
         if (player == null) return false;

--- a/folia/src/main/java/io/tebex/plugin/FoliaPluginPlatform.java
+++ b/folia/src/main/java/io/tebex/plugin/FoliaPluginPlatform.java
@@ -146,12 +146,6 @@ public class FoliaPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        Player player = getPlayer(playerName);
-        return player == null ? null : player.getUniqueId();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         Player player = getPlayer(username);
         return player != null && player.hasPermission(permission);

--- a/folia/src/main/java/io/tebex/plugin/FoliaPluginPlatform.java
+++ b/folia/src/main/java/io/tebex/plugin/FoliaPluginPlatform.java
@@ -146,6 +146,12 @@ public class FoliaPluginPlatform extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        Player player = getPlayer(playerName);
+        return player == null ? null : player.getUniqueId();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         Player player = getPlayer(username);
         return player != null && player.hasPermission(permission);

--- a/folia/src/main/java/io/tebex/plugin/gui/BuyGUI.java
+++ b/folia/src/main/java/io/tebex/plugin/gui/BuyGUI.java
@@ -111,7 +111,7 @@ public class BuyGUI {
                     // Create Checkout Url
                     platform.getSDK().createCheckoutUrl(categoryPackage.getId(), player.getName())
                             .thenAccept(checkout -> {
-                                player.sendMessage(ChatColor.GREEN + "You can checkout here: " + checkout.getUrl());
+                                platform.sendCheckoutLink(player.getName(), checkout.getUrl());
                             }).exceptionally(ex -> {
                                 player.sendMessage(ChatColor.RED
                                         + "Failed to create checkout URL. Please contact an administrator.");

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation("dev.dejvokep:boosted-yaml:1.3")
     implementation("com.google.code.gson:gson:2.10.1")
 
+    compileOnly("org.geysermc.cumulus:cumulus:1.1.2")
     compileOnly("org.geysermc.floodgate:api:2.2.5-SNAPSHOT")
 
     compileOnly("org.projectlombok:lombok:1.18.38")

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation("dev.dejvokep:boosted-yaml:1.3")
     implementation("com.google.code.gson:gson:2.10.1")
 
-    compileOnly("org.geysermc.cumulus:cumulus:1.1.2")
     compileOnly("org.geysermc.floodgate:api:2.2.5-SNAPSHOT")
 
     compileOnly("org.projectlombok:lombok:1.18.38")

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
     implementation("dev.dejvokep:boosted-yaml:1.3")
     implementation("com.google.code.gson:gson:2.10.1")
 
+    compileOnly("org.geysermc.floodgate:api:2.2.5-SNAPSHOT")
+
     compileOnly("org.projectlombok:lombok:1.18.38")
     annotationProcessor("org.projectlombok:lombok:1.18.38")
     testCompileOnly("org.projectlombok:lombok:1.18.38")

--- a/sdk/src/main/java/io/tebex/sdk/commands/TebexCommands.java
+++ b/sdk/src/main/java/io/tebex/sdk/commands/TebexCommands.java
@@ -162,7 +162,8 @@ public class TebexCommands {
             }
 
             platform.getSDK().createCheckoutUrl(intPackageId, ctx.getSenderUsername()).thenAccept((url) -> {
-                response.complete(new String[] { Responder.formatFancy(ctx, "Checkout started! Click here to complete payment: {0}", url.getUrl())});
+                platform.sendCheckoutLink(ctx.getSenderUsername(), url.getUrl());
+                response.complete(new String[] { Responder.formatSuccess(ctx, "Checkout link sent to you.")});
             }).exceptionally(e -> {
                 response.complete(new String[] { Responder.formatError(ctx, e.getMessage())});
                 return null;
@@ -323,7 +324,7 @@ public class TebexCommands {
             }
 
             platform.getSDK().createCheckoutUrl(intPackageId, ctx.getTargetUsername()).thenAccept(checkoutUrl -> {
-                Responder.tellOtherFancy(ctx, "A checkout link has been created for you. Click here to complete payment: {0}", checkoutUrl.getUrl());
+                platform.sendCheckoutLink(ctx.getTargetUsername(), checkoutUrl.getUrl());
                 response.complete(new String[]{Responder.formatSuccess(ctx, "Checkout link sent to " + ctx.getTargetUsername())});
             }).exceptionally(e -> {
                 response.complete(new String[]{Responder.formatError(ctx, "Failed to send checkout link: " + e.getMessage())});

--- a/sdk/src/main/java/io/tebex/sdk/obj/QueuedCommand.java
+++ b/sdk/src/main/java/io/tebex/sdk/obj/QueuedCommand.java
@@ -1,6 +1,6 @@
 package io.tebex.sdk.obj;
 
-import io.tebex.sdk.util.UUIDUtil;
+import io.tebex.sdk.platform.PluginPlatform;
 import lombok.Data;
 
 @Data
@@ -15,31 +15,26 @@ public class QueuedCommand {
     private final boolean online;
 
     public String getParsedCommand() {
+        return getParsedCommand(null);
+    }
+
+    public String getParsedCommand(PluginPlatform platform) {
         String parsedCommand = command;
 
         if (player != null) {
+            String commandPlayerId = platform == null
+                    ? player.getDefaultCommandIdentifier()
+                    : platform.resolveCommandPlayerId(player);
+            if (commandPlayerId == null) {
+                commandPlayerId = player.getDefaultCommandIdentifier();
+            }
+
             parsedCommand = parsedCommand.replace("{username}", player.getName());
             parsedCommand = parsedCommand.replace("{name}", player.getName());
-
-            if (isMissingUuid(player.getUuid())) {
-                // Offline/unauthenticated players: fall back to username for both placeholders
-                parsedCommand = parsedCommand.replace("{id}", player.getName());
-                parsedCommand = parsedCommand.replace("{uuid}", player.getName());
-            } else {
-                parsedCommand = parsedCommand.replace("{id}", player.getUuid());
-                parsedCommand = parsedCommand.replace("{uuid}", player.getUuid());
-            }
+            parsedCommand = parsedCommand.replace("{id}", commandPlayerId);
+            parsedCommand = parsedCommand.replace("{uuid}", commandPlayerId);
         }
 
         return parsedCommand;
-    }
-
-    private boolean isMissingUuid(String uuid) {
-        if (uuid == null) return true;
-
-        String trimmed = uuid.trim();
-        return trimmed.isEmpty()
-                || trimmed.equalsIgnoreCase("null")
-                || trimmed.equalsIgnoreCase(UUIDUtil.EMPTY_UUID.toString());
     }
 }

--- a/sdk/src/main/java/io/tebex/sdk/obj/QueuedPlayer.java
+++ b/sdk/src/main/java/io/tebex/sdk/obj/QueuedPlayer.java
@@ -3,13 +3,13 @@ package io.tebex.sdk.obj;
 import com.google.gson.JsonObject;
 import io.tebex.sdk.util.UUIDUtil;
 import lombok.Data;
-import lombok.Getter;
 
 @Data
 public class QueuedPlayer {
     private final int id;
     private final String name;
     private final String uuid;
+    private final String xuid;
 
     /**
      * Constructs a Player instance.
@@ -19,16 +19,95 @@ public class QueuedPlayer {
      * @param uuid The player UUID. If truncated, is transformed into java-style uuid ("00000000-0000-0000-etc...")
      */
     public QueuedPlayer(int id, String name, String uuid) {
+        this(id, name, uuid, null);
+    }
+
+    public QueuedPlayer(int id, String name, String uuid, String xuid) {
         this.id = id;
         this.name = name;
-        this.uuid = String.valueOf(UUIDUtil.mojangIdToJavaId(uuid)); // tebex API returns truncated uuids
+        this.uuid = normalizeUuid(uuid);
+        this.xuid = normalizeXuid(xuid);
     }
 
     public static QueuedPlayer fromJson(JsonObject object) {
+        String rawUuid = object.has("uuid") && !object.get("uuid").isJsonNull()
+                ? object.get("uuid").getAsString()
+                : null;
+        String rawXuid = object.has("xuid") && !object.get("xuid").isJsonNull()
+                ? object.get("xuid").getAsString()
+                : null;
+
+        if (rawXuid == null && looksLikeXuid(rawUuid)) {
+            rawXuid = rawUuid;
+            rawUuid = null;
+        }
+
         return new QueuedPlayer(
                 object.get("id").getAsInt(),
                 object.get("name").getAsString(),
-                !object.get("uuid").isJsonNull() ? object.get("uuid").getAsString() : null
+                rawUuid,
+                rawXuid
         );
+    }
+
+    public boolean hasUuid() {
+        return uuid != null && !UUIDUtil.EMPTY_UUID.toString().equals(uuid);
+    }
+
+    public boolean hasXuid() {
+        return xuid != null && !xuid.isEmpty();
+    }
+
+    public Long getXuidAsLong() {
+        if (!hasXuid()) {
+            return null;
+        }
+
+        try {
+            if (xuid.matches("\\d+")) {
+                return Long.parseUnsignedLong(xuid);
+            }
+
+            if (xuid.matches("(?i)[0-9a-f]{16}")) {
+                return Long.parseUnsignedLong(xuid, 16);
+            }
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+
+        return null;
+    }
+
+    public String getDefaultCommandIdentifier() {
+        return hasUuid() ? uuid : (name == null ? "" : name);
+    }
+
+    private static String normalizeUuid(String uuid) {
+        if (isBlank(uuid) || looksLikeXuid(uuid)) {
+            return null;
+        }
+
+        return UUIDUtil.mojangIdToJavaId(uuid.trim()).toString();
+    }
+
+    private static String normalizeXuid(String xuid) {
+        if (isBlank(xuid)) {
+            return null;
+        }
+
+        return xuid.trim();
+    }
+
+    private static boolean looksLikeXuid(String identifier) {
+        if (isBlank(identifier)) {
+            return false;
+        }
+
+        String trimmed = identifier.trim();
+        return trimmed.matches("\\d+") || trimmed.matches("(?i)[0-9a-f]{16}");
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty() || value.trim().equalsIgnoreCase("null");
     }
 }

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -322,6 +322,7 @@ public abstract class BasePluginPlatform implements PluginPlatform {
                     .title("Checkout")
                     .label("Open this checkout link in your browser to complete payment.")
                     .input("Checkout URL", "", checkoutUrl)
+                    .validResultHandler(response -> sendPlayerMessage(playerName, "Checkout link: " + checkoutUrl))
                     .closedOrInvalidResultHandler(() -> sendPlayerMessage(playerName, "Checkout link: " + checkoutUrl))
                     .build();
 

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -247,6 +247,16 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         return player.getDefaultCommandIdentifier();
     }
 
+    @Override
+    public void sendCheckoutLink(String playerName, String checkoutUrl) {
+        if (isOnlineFloodgatePlayer(playerName)) {
+            sendPlayerMessage(playerName, "Checkout started! Type this link into your browser: " + checkoutUrl);
+            return;
+        }
+
+        PluginPlatform.super.sendCheckoutLink(playerName, checkoutUrl);
+    }
+
     private UUID resolveFloodgateUniqueId(QueuedPlayer player) {
         if (!isGeyser()) {
             return null;
@@ -291,6 +301,20 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         }
 
         return null;
+    }
+
+    private boolean isOnlineFloodgatePlayer(String playerName) {
+        UUID playerUniqueId = getPlayerUniqueId(playerName);
+        if (playerUniqueId == null) {
+            return false;
+        }
+
+        try {
+            return FloodgateApi.getInstance().isFloodgatePlayer(playerUniqueId);
+        } catch (IllegalStateException | NoClassDefFoundError e) {
+            warnMissingFloodgateApi();
+            return false;
+        }
     }
 
     private void warnMissingFloodgateApi() {

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -14,7 +14,7 @@ import io.tebex.sdk.triage.EnumEventLevel;
 import io.tebex.sdk.triage.PluginEvent;
 import io.tebex.sdk.util.*;
 import org.jetbrains.annotations.NotNull;
-import org.geysermc.cumulus.form.CustomForm;
+import org.geysermc.cumulus.form.SimpleForm;
 import org.geysermc.floodgate.api.FloodgateApi;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.util.LinkedPlayer;
@@ -318,12 +318,10 @@ public abstract class BasePluginPlatform implements PluginPlatform {
                     ? floodgatePlayer.getCorrectUniqueId()
                     : playerUniqueId;
 
-            CustomForm form = CustomForm.builder()
+            SimpleForm form = SimpleForm.builder()
                     .title("Checkout")
-                    .label("Open this checkout link in your browser to complete payment.")
-                    .input("Checkout URL", "", checkoutUrl)
-                    .validResultHandler(response -> sendPlayerMessage(playerName, "Checkout link: " + checkoutUrl))
-                    .closedOrInvalidResultHandler(() -> sendPlayerMessage(playerName, "Checkout link: " + checkoutUrl))
+                    .content("Type the following link into your browser to checkout:\n" + checkoutUrl)
+                    .button("Close")
                     .build();
 
             if (api.sendForm(recipientId, form)) {

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -14,12 +14,16 @@ import io.tebex.sdk.triage.EnumEventLevel;
 import io.tebex.sdk.triage.PluginEvent;
 import io.tebex.sdk.util.*;
 import org.jetbrains.annotations.NotNull;
+import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.floodgate.api.player.FloodgatePlayer;
+import org.geysermc.floodgate.util.LinkedPlayer;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
@@ -45,6 +49,8 @@ public abstract class BasePluginPlatform implements PluginPlatform {
 
     private final ArrayList<PluginEvent> PLUGIN_EVENTS = new ArrayList<>();
     private final AtomicBoolean commandCheckInProgress = new AtomicBoolean(false);
+    private final AtomicBoolean floodgateWarningLogged = new AtomicBoolean(false);
+    private final Map<String, UUID> resolvedFloodgateIds = Maps.newConcurrentMap();
 
     /**
      * Checks if the configured store is Geyser/Offline
@@ -54,17 +60,19 @@ public abstract class BasePluginPlatform implements PluginPlatform {
     public final boolean isGeyser() {
         if (!isSetup()) return false;
 
-        if (getStoreType() == null || getStoreType().isEmpty()) {
+        String storeType = getStoreType();
+        if (storeType == null || storeType.isEmpty()) {
             return false;
         }
 
-        return getStoreType().contains("Offline/Geyser");
+        return storeType.toLowerCase(Locale.ROOT).contains("geyser");
     }
 
     public final void initStore() {
         sdk = new SDK(this, config.getSecretKey());
         placeholderManager = new PlaceholderManager();
         queuedPlayers = Maps.newConcurrentMap();
+        resolvedFloodgateIds.clear();
         storeCategories = new ArrayList<>();
         serverEvents = Collections.synchronizedList(new ArrayList<>());
         placeholderManager.register(new UuidPlaceholder(placeholderManager));
@@ -217,6 +225,85 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         return (name == null) ? "" : name;
     }
 
+    @Override
+    public String resolveCommandPlayerId(QueuedPlayer player) {
+        if (player == null) {
+            return "";
+        }
+
+        if (player.hasUuid()) {
+            return player.getUuid();
+        }
+
+        if (!player.hasXuid()) {
+            return player.getDefaultCommandIdentifier();
+        }
+
+        UUID resolvedUuid = resolvedFloodgateIds.computeIfAbsent(player.getXuid(), ignored -> resolveFloodgateUniqueId(player));
+        if (resolvedUuid != null && !UUIDUtil.EMPTY_UUID.equals(resolvedUuid)) {
+            return resolvedUuid.toString();
+        }
+
+        return player.getDefaultCommandIdentifier();
+    }
+
+    private UUID resolveFloodgateUniqueId(QueuedPlayer player) {
+        if (!isGeyser()) {
+            return null;
+        }
+
+        Long xuid = player.getXuidAsLong();
+        if (xuid == null) {
+            debug("Unable to parse Bedrock XUID '" + player.getXuid() + "' for player '" + player.getName() + "'.");
+            return null;
+        }
+
+        try {
+            FloodgateApi api = FloodgateApi.getInstance();
+            UUID bedrockId = api.createJavaPlayerId(xuid);
+
+            if (bedrockId == null || UUIDUtil.EMPTY_UUID.equals(bedrockId)) {
+                return null;
+            }
+
+            FloodgatePlayer onlinePlayer = api.getPlayer(bedrockId);
+            if (onlinePlayer != null && onlinePlayer.getCorrectUniqueId() != null) {
+                return onlinePlayer.getCorrectUniqueId();
+            }
+
+            if (api.getPlayerLink() != null) {
+                try {
+                    LinkedPlayer linkedPlayer = api.getPlayerLink().getLinkedPlayer(bedrockId).get(2, TimeUnit.SECONDS);
+                    if (linkedPlayer != null && linkedPlayer.getJavaUniqueId() != null) {
+                        return linkedPlayer.getJavaUniqueId();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    debug("Interrupted while resolving Floodgate UUID for player '" + player.getName() + "'.");
+                } catch (ExecutionException | TimeoutException e) {
+                    debug("Failed to resolve Floodgate link data for player '" + player.getName() + "': " + e.getMessage());
+                }
+            }
+
+            return bedrockId;
+        } catch (IllegalStateException | NoClassDefFoundError e) {
+            warnMissingFloodgateApi();
+        }
+
+        return null;
+    }
+
+    private void warnMissingFloodgateApi() {
+        if (!floodgateWarningLogged.compareAndSet(false, true)) {
+            return;
+        }
+
+        warning(
+                "Received a Bedrock XUID for command placeholder resolution, but the Floodgate API is unavailable.",
+                "Install Floodgate on the same server or proxy running Tebex so {id}/{uuid} placeholders can be resolved for Bedrock players."
+        );
+    }
+
     /**
      * Processes the online commands for a player.
      *
@@ -230,16 +317,17 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         List<Integer> completedCommands = new ArrayList<>();
         boolean hasInventorySpace = true;
         for (QueuedCommand command : commands) {
+            String parsedCommand = command.getParsedCommand(this);
             int freeSlots = getFreeSlots(playerId);
             if(freeSlots < command.getRequiredSlots()) {
-                info(String.format("Skipping command '%s' for player '%s' due to no inventory space. Free slots: %d. Slots required: %d", command.getParsedCommand(), playerName, freeSlots, command.getRequiredSlots()));
+                info(String.format("Skipping command '%s' for player '%s' due to no inventory space. Free slots: %d. Slots required: %d", parsedCommand, playerName, freeSlots, command.getRequiredSlots()));
                 hasInventorySpace = false;
                 continue;
             }
 
             final Runnable commandRunnable = () -> {
-                info(String.format("Dispatching command '%s' for player '%s'", command.getParsedCommand(), playerName));
-                CommandResult commandResult = dispatchCommand(command.getParsedCommand());
+                info(String.format("Dispatching command '%s' for player '%s'", parsedCommand, playerName));
+                CommandResult commandResult = dispatchCommand(parsedCommand);
 
                 // report whether the command succeeded or failed
                 if (!commandResult.isSuccess()) {
@@ -256,7 +344,7 @@ public abstract class BasePluginPlatform implements PluginPlatform {
                         extraInfo = "No further information";
                     }
 
-                    String solution = String.format("Manually try `%s` for player %s. Check that the command syntax is correct.", command.getParsedCommand(), playerName);
+                    String solution = String.format("Manually try `%s` for player %s. Check that the command syntax is correct.", parsedCommand, playerName);
                     if (command.getPayment() != 0) {
                         solution += " Re-run this command at https://creator.tebex.io/payments/" + command.getPayment();
                     }
@@ -301,9 +389,10 @@ public abstract class BasePluginPlatform implements PluginPlatform {
 
             List<Integer> completedCommands = new ArrayList<>();
             for (QueuedCommand command : offlineData.getCommands()) {
+                String parsedCommand = command.getParsedCommand(this);
                 final Runnable commandRunnable = () -> {
-                    info(String.format("Dispatching offline command '%s' for player '%s'.", command.getParsedCommand(), command.getPlayer().getName()));
-                    CommandResult offlineCommandResult = dispatchCommand(command.getParsedCommand());
+                    info(String.format("Dispatching offline command '%s' for player '%s'.", parsedCommand, command.getPlayer().getName()));
+                    CommandResult offlineCommandResult = dispatchCommand(parsedCommand);
 
                     // report whether the offline command succeeded or failed
                     if (!offlineCommandResult.isSuccess()) {
@@ -320,7 +409,7 @@ public abstract class BasePluginPlatform implements PluginPlatform {
                         if (command.getPayment() != 0) {
                             solution += " Re-run this command at https://creator.tebex.io/payments/" + command.getPayment();
                         }
-                        warning(String.format("Command `%s` failed to execute: %s", command.getParsedCommand(), extraInfo), solution);
+                        warning(String.format("Command `%s` failed to execute: %s", parsedCommand, extraInfo), solution);
                     }
                 };
                 if (command.getDelay() > 0) {

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -14,6 +14,7 @@ import io.tebex.sdk.triage.EnumEventLevel;
 import io.tebex.sdk.triage.PluginEvent;
 import io.tebex.sdk.util.*;
 import org.jetbrains.annotations.NotNull;
+import org.geysermc.cumulus.form.CustomForm;
 import org.geysermc.floodgate.api.FloodgateApi;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.util.LinkedPlayer;
@@ -247,6 +248,13 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         return player.getDefaultCommandIdentifier();
     }
 
+    @Override
+    public void sendCheckoutLink(String playerName, String checkoutUrl) {
+        if (!trySendBedrockCheckoutForm(playerName, checkoutUrl)) {
+            PluginPlatform.super.sendCheckoutLink(playerName, checkoutUrl);
+        }
+    }
+
     private UUID resolveFloodgateUniqueId(QueuedPlayer player) {
         if (!isGeyser()) {
             return null;
@@ -291,6 +299,40 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         }
 
         return null;
+    }
+
+    private boolean trySendBedrockCheckoutForm(String playerName, String checkoutUrl) {
+        UUID playerUniqueId = getPlayerUniqueId(playerName);
+        if (playerUniqueId == null) {
+            return false;
+        }
+
+        try {
+            FloodgateApi api = FloodgateApi.getInstance();
+            if (!api.isFloodgatePlayer(playerUniqueId)) {
+                return false;
+            }
+
+            FloodgatePlayer floodgatePlayer = api.getPlayer(playerUniqueId);
+            UUID recipientId = floodgatePlayer != null && floodgatePlayer.getCorrectUniqueId() != null
+                    ? floodgatePlayer.getCorrectUniqueId()
+                    : playerUniqueId;
+
+            CustomForm form = CustomForm.builder()
+                    .title("Checkout")
+                    .label("Open this checkout link in your browser to complete payment.")
+                    .input("Checkout URL", "", checkoutUrl)
+                    .closedOrInvalidResultHandler(() -> sendPlayerMessage(playerName, "Checkout link: " + checkoutUrl))
+                    .build();
+
+            if (api.sendForm(recipientId, form)) {
+                return true;
+            }
+        } catch (IllegalStateException | NoClassDefFoundError e) {
+            warnMissingFloodgateApi();
+        }
+
+        return false;
     }
 
     private void warnMissingFloodgateApi() {

--- a/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/BasePluginPlatform.java
@@ -14,7 +14,6 @@ import io.tebex.sdk.triage.EnumEventLevel;
 import io.tebex.sdk.triage.PluginEvent;
 import io.tebex.sdk.util.*;
 import org.jetbrains.annotations.NotNull;
-import org.geysermc.cumulus.form.SimpleForm;
 import org.geysermc.floodgate.api.FloodgateApi;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
 import org.geysermc.floodgate.util.LinkedPlayer;
@@ -248,13 +247,6 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         return player.getDefaultCommandIdentifier();
     }
 
-    @Override
-    public void sendCheckoutLink(String playerName, String checkoutUrl) {
-        if (!trySendBedrockCheckoutForm(playerName, checkoutUrl)) {
-            PluginPlatform.super.sendCheckoutLink(playerName, checkoutUrl);
-        }
-    }
-
     private UUID resolveFloodgateUniqueId(QueuedPlayer player) {
         if (!isGeyser()) {
             return null;
@@ -299,39 +291,6 @@ public abstract class BasePluginPlatform implements PluginPlatform {
         }
 
         return null;
-    }
-
-    private boolean trySendBedrockCheckoutForm(String playerName, String checkoutUrl) {
-        UUID playerUniqueId = getPlayerUniqueId(playerName);
-        if (playerUniqueId == null) {
-            return false;
-        }
-
-        try {
-            FloodgateApi api = FloodgateApi.getInstance();
-            if (!api.isFloodgatePlayer(playerUniqueId)) {
-                return false;
-            }
-
-            FloodgatePlayer floodgatePlayer = api.getPlayer(playerUniqueId);
-            UUID recipientId = floodgatePlayer != null && floodgatePlayer.getCorrectUniqueId() != null
-                    ? floodgatePlayer.getCorrectUniqueId()
-                    : playerUniqueId;
-
-            SimpleForm form = SimpleForm.builder()
-                    .title("Checkout")
-                    .content("Type the following link into your browser to checkout:\n" + checkoutUrl)
-                    .button("Close")
-                    .build();
-
-            if (api.sendForm(recipientId, form)) {
-                return true;
-            }
-        } catch (IllegalStateException | NoClassDefFoundError e) {
-            warnMissingFloodgateApi();
-        }
-
-        return false;
     }
 
     private void warnMissingFloodgateApi() {

--- a/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
@@ -129,16 +129,6 @@ public interface PluginPlatform {
     }
 
     /**
-     * Returns the UUID of an online player when available.
-     *
-     * @param playerName The player's username.
-     * @return The online player's UUID, or null when unavailable.
-     */
-    default java.util.UUID getPlayerUniqueId(String playerName) {
-        return null;
-    }
-
-    /**
      * Resolves the identifier that should fill {id} and {uuid} placeholders for a queued player.
      *
      * @param player The queued player record from Tebex.

--- a/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
@@ -129,6 +129,16 @@ public interface PluginPlatform {
     }
 
     /**
+     * Returns the UUID of an online player when available.
+     *
+     * @param playerName The player's username.
+     * @return The online player's UUID, or null when unavailable.
+     */
+    default java.util.UUID getPlayerUniqueId(String playerName) {
+        return null;
+    }
+
+    /**
      * Resolves the identifier that should fill {id} and {uuid} placeholders for a queued player.
      *
      * @param player The queued player record from Tebex.
@@ -142,6 +152,16 @@ public interface PluginPlatform {
      * @return Number of inventory slots free for the given player
      */
     int getFreeSlots(Object player);
+
+    /**
+     * Sends a checkout link to a player.
+     *
+     * @param playerName The player who should receive the link.
+     * @param checkoutUrl The Tebex checkout URL.
+     */
+    default void sendCheckoutLink(String playerName, String checkoutUrl) {
+        sendPlayerMessage(playerName, "Checkout started! Complete payment here: " + checkoutUrl);
+    }
 
     void setServerInformation(ServerInformation serverInformation);
 

--- a/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
@@ -129,6 +129,16 @@ public interface PluginPlatform {
     }
 
     /**
+     * Returns the UUID of an online player when available.
+     *
+     * @param playerName The player's username.
+     * @return The online player's UUID, or null when unavailable.
+     */
+    default java.util.UUID getPlayerUniqueId(String playerName) {
+        return null;
+    }
+
+    /**
      * Resolves the identifier that should fill {id} and {uuid} placeholders for a queued player.
      *
      * @param player The queued player record from Tebex.

--- a/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
+++ b/sdk/src/main/java/io/tebex/sdk/platform/PluginPlatform.java
@@ -2,6 +2,7 @@ package io.tebex.sdk.platform;
 
 import dev.dejvokep.boostedyaml.YamlDocument;
 import io.tebex.sdk.SDK;
+import io.tebex.sdk.obj.QueuedPlayer;
 import io.tebex.sdk.platform.config.IPlatformConfig;
 import io.tebex.sdk.request.response.ServerInformation;
 import io.tebex.sdk.util.CommandResult;
@@ -125,6 +126,16 @@ public interface PluginPlatform {
      */
     default boolean isPlayerOnline(Object player) {
         return getPlayer(player) != null;
+    }
+
+    /**
+     * Resolves the identifier that should fill {id} and {uuid} placeholders for a queued player.
+     *
+     * @param player The queued player record from Tebex.
+     * @return The identifier to inject into queued commands.
+     */
+    default String resolveCommandPlayerId(QueuedPlayer player) {
+        return player == null ? "" : player.getDefaultCommandIdentifier();
     }
 
     /**

--- a/sdk/src/test/java/io/tebex/sdk/obj/QueuedCommandTest.java
+++ b/sdk/src/test/java/io/tebex/sdk/obj/QueuedCommandTest.java
@@ -1,5 +1,6 @@
 package io.tebex.sdk.obj;
 
+import io.tebex.sdk.platform.MockPluginPlatform;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,5 +65,49 @@ class QueuedCommandTest {
         String parsed = command.getParsedCommand();
 
         assertEquals("lp user 12345678-1234-1234-1234-1234567890ab parent add default", parsed);
+    }
+
+    @Test
+    void bedrockPlayersFallbackToNameWithoutPlatformResolver() {
+        QueuedPlayer bedrockPlayer = new QueuedPlayer(4, "BedrockUser", null, "281474976710655");
+        QueuedCommand command = new QueuedCommand(
+                13,
+                "grant {id} {uuid}",
+                0,
+                0,
+                0,
+                0,
+                bedrockPlayer,
+                true
+        );
+
+        String parsed = command.getParsedCommand();
+
+        assertEquals("grant BedrockUser BedrockUser", parsed);
+    }
+
+    @Test
+    void bedrockPlayersUsePlatformResolvedIdentifier() {
+        QueuedPlayer bedrockPlayer = new QueuedPlayer(5, "BedrockUser", null, "281474976710655");
+        QueuedCommand command = new QueuedCommand(
+                14,
+                "grant {id} {uuid}",
+                0,
+                0,
+                0,
+                0,
+                bedrockPlayer,
+                true
+        );
+        MockPluginPlatform platform = new MockPluginPlatform() {
+            @Override
+            public String resolveCommandPlayerId(QueuedPlayer player) {
+                return "00000000-0000-0000-0001-000000000001";
+            }
+        };
+
+        String parsed = command.getParsedCommand(platform);
+
+        assertEquals("grant 00000000-0000-0000-0001-000000000001 00000000-0000-0000-0001-000000000001", parsed);
     }
 }

--- a/sdk/src/test/java/io/tebex/sdk/obj/QueuedPlayerTest.java
+++ b/sdk/src/test/java/io/tebex/sdk/obj/QueuedPlayerTest.java
@@ -1,0 +1,40 @@
+package io.tebex.sdk.obj;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueuedPlayerTest {
+
+    @Test
+    void fromJsonTreatsNumericUuidAsXuid() {
+        JsonObject playerJson = JsonParser.parseString("{\"id\":1,\"name\":\"BedrockUser\",\"uuid\":\"281474976710655\"}")
+                .getAsJsonObject();
+
+        QueuedPlayer player = QueuedPlayer.fromJson(playerJson);
+
+        assertNull(player.getUuid());
+        assertEquals("281474976710655", player.getXuid());
+        assertEquals(Long.valueOf(281474976710655L), player.getXuidAsLong());
+        assertFalse(player.hasUuid());
+        assertTrue(player.hasXuid());
+    }
+
+    @Test
+    void fromJsonKeepsExplicitJavaUuidAndXuid() {
+        JsonObject playerJson = JsonParser.parseString("{\"id\":2,\"name\":\"LinkedUser\",\"uuid\":\"123456781234123412341234567890ab\",\"xuid\":\"281474976710655\"}")
+                .getAsJsonObject();
+
+        QueuedPlayer player = QueuedPlayer.fromJson(playerJson);
+
+        assertEquals("12345678-1234-1234-1234-1234567890ab", player.getUuid());
+        assertEquals("281474976710655", player.getXuid());
+        assertTrue(player.hasUuid());
+        assertTrue(player.hasXuid());
+    }
+}

--- a/velocity/src/main/java/io/tebex/plugin/TebexVelocityPlugin.java
+++ b/velocity/src/main/java/io/tebex/plugin/TebexVelocityPlugin.java
@@ -219,6 +219,12 @@ public class TebexVelocityPlugin extends BasePluginPlatform {
     }
 
     @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        Player player = getPlayer(playerName);
+        return player == null ? null : player.getUniqueId();
+    }
+
+    @Override
     public boolean hasPermission(String username, String permission) {
         Player player = getPlayer(username);
         return player != null && player.hasPermission(permission);

--- a/velocity/src/main/java/io/tebex/plugin/TebexVelocityPlugin.java
+++ b/velocity/src/main/java/io/tebex/plugin/TebexVelocityPlugin.java
@@ -219,12 +219,6 @@ public class TebexVelocityPlugin extends BasePluginPlatform {
     }
 
     @Override
-    public UUID getPlayerUniqueId(String playerName) {
-        Player player = getPlayer(playerName);
-        return player == null ? null : player.getUniqueId();
-    }
-
-    @Override
     public boolean hasPermission(String username, String permission) {
         Player player = getPlayer(username);
         return player != null && player.hasPermission(permission);


### PR DESCRIPTION
Tebex can now accept Bedrock players from Geyser/Floodgate stores, preserves their XUID from the API and resolves them into valid Floodgate UUID's for command processing.

Due to limitations in Bedrock, the messaging needed changed slightly specifically for Bedrock players to let them know that the URL must be hand-typed into their web browser in order to complete checkout. Java remains untouched.

There was also a few inconsistencies across our various supported platforms, these have now been unified across all plugin types.