### PR TITLE
Add HuskSync-aware join handling and fix Velocity Gradle plugin conflict

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -3,11 +3,19 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 group = rootProject.group
 version = rootProject.version
 
+repositories {
+    maven {
+        name = "william278"
+        url = uri("https://repo.william278.net/releases")
+    }
+}
+
 dependencies {
     implementation(project(":sdk"))
     implementation("com.github.cryptomorin:XSeries:9.3.1") { isTransitive = false }
     compileOnly("org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT")
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
+    compileOnly("net.william278.husksync:husksync-bukkit:3.8.7+1.21.4")
 }
 
 tasks.named("shadowJar", ShadowJar::class.java) {

--- a/bukkit/src/main/java/io/tebex/plugin/TebexBukkitPlugin.java
+++ b/bukkit/src/main/java/io/tebex/plugin/TebexBukkitPlugin.java
@@ -5,7 +5,8 @@ import dev.dejvokep.boostedyaml.YamlDocument;
 import io.tebex.plugin.command.BuyCommand;
 import io.tebex.plugin.command.TebexCommandExecutor;
 import io.tebex.plugin.event.InventoryClickListener;
-import io.tebex.plugin.event.PlayerJoinListener;
+import io.tebex.plugin.event.join.HuskSyncPlayerJoinListener;
+import io.tebex.plugin.event.join.PlayerJoinListener;
 import io.tebex.plugin.placeholder.BukkitNamePlaceholder;
 import io.tebex.sdk.Tebex;
 import io.tebex.sdk.obj.ServerEvent;
@@ -61,7 +62,13 @@ public final class TebexBukkitPlugin extends JavaPlugin {
         pluginCommand.setTabCompleter(tebexCommands);
 
         registerBuyCommandIfEnabled();
-        registerEvents(new PlayerJoinListener(platform));
+
+        if (getServer().getPluginManager().isPluginEnabled("HuskSync")) {
+            registerEvents(new HuskSyncPlayerJoinListener(platform));
+        } else {
+            registerEvents(new PlayerJoinListener(platform));
+        }
+
         registerEvents(new InventoryClickListener());
 
         PlaceholderManager placeholderManager = platform.getPlaceholderManager();

--- a/bukkit/src/main/java/io/tebex/plugin/event/join/HuskSyncPlayerJoinListener.java
+++ b/bukkit/src/main/java/io/tebex/plugin/event/join/HuskSyncPlayerJoinListener.java
@@ -1,0 +1,34 @@
+package io.tebex.plugin.event.join;
+
+import io.tebex.plugin.BukkitPluginPlatform;
+import net.kyori.adventure.audience.Audience;
+import net.william278.husksync.event.BukkitSyncCompleteEvent;
+import net.william278.husksync.user.OnlineUser;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+
+public class HuskSyncPlayerJoinListener extends PlayerJoinListener {
+
+    public HuskSyncPlayerJoinListener(BukkitPluginPlatform platform) {
+        super(platform);
+    }
+
+    @EventHandler
+    private void onBukkitSyncComplete(BukkitSyncCompleteEvent event) {
+        OnlineUser user = event.getUser();
+
+        if (user == null) {
+            return;
+        }
+
+        Audience audience = user.getAudience();
+        if (audience == null) {
+            return;
+        }
+
+        if (audience instanceof Player) {
+            Player player = (Player) audience;
+            handlePlayerJoin(player);
+        }
+    }
+}

--- a/bukkit/src/main/java/io/tebex/plugin/event/join/JoinListenerBase.java
+++ b/bukkit/src/main/java/io/tebex/plugin/event/join/JoinListenerBase.java
@@ -1,22 +1,19 @@
-package io.tebex.plugin.event;
+package io.tebex.plugin.event.join;
 
-import io.tebex.plugin.FoliaPluginPlatform;
+import io.tebex.plugin.BukkitPluginPlatform;
 import io.tebex.sdk.obj.QueuedPlayer;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
 
-public class PlayerJoinListener implements Listener {
-    private final FoliaPluginPlatform platform;
+public abstract class JoinListenerBase implements Listener {
 
-    public PlayerJoinListener(FoliaPluginPlatform platform) {
+    private final BukkitPluginPlatform platform;
+
+    public JoinListenerBase(BukkitPluginPlatform platform) {
         this.platform = platform;
     }
 
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
+    protected void handlePlayerJoin(Player player) {
         Object playerId = platform.getPlayerId(player.getName(), player.getUniqueId());
         platform.createJoinEvent(player.getUniqueId().toString(), player.getName(), player.getAddress().getAddress().getHostAddress());
 

--- a/bukkit/src/main/java/io/tebex/plugin/event/join/PlayerJoinListener.java
+++ b/bukkit/src/main/java/io/tebex/plugin/event/join/PlayerJoinListener.java
@@ -1,0 +1,17 @@
+package io.tebex.plugin.event.join;
+
+import io.tebex.plugin.BukkitPluginPlatform;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class PlayerJoinListener extends JoinListenerBase {
+
+    public PlayerJoinListener(BukkitPluginPlatform platform) {
+        super(platform);
+    }
+
+    @EventHandler
+    private void onPlayerJoin(PlayerJoinEvent event) {
+        handlePlayerJoin(event.getPlayer());
+    }
+}

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ main: io.tebex.plugin.TebexBukkitPlugin
 api-version: 1.13
 softdepend:
   - BuycraftX
+  - HuskSync
 commands:
   tebex:
     description: The main command

--- a/folia/build.gradle.kts
+++ b/folia/build.gradle.kts
@@ -8,6 +8,10 @@ repositories {
     maven { url = uri("https://repo.papermc.io/repository/maven-public/") }
     maven { url = uri("https://jitpack.io") }
     maven { url = uri("https://repo.extendedclip.com/content/repositories/placeholderapi/") }
+    maven {
+        name = "william278"
+        url = uri("https://repo.william278.net/releases")
+    }
 }
 
 dependencies {
@@ -15,6 +19,7 @@ dependencies {
     implementation("com.github.cryptomorin:XSeries:9.3.1") { isTransitive = false }
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     compileOnly("dev.dejvokep:boosted-yaml:1.3")
+    compileOnly("net.william278.husksync:husksync-bukkit:3.8.7+1.21.4")
 }
 
 tasks.named("shadowJar", ShadowJar::class.java) {

--- a/folia/src/main/java/io/tebex/plugin/TebexFoliaPlugin.java
+++ b/folia/src/main/java/io/tebex/plugin/TebexFoliaPlugin.java
@@ -5,7 +5,8 @@ import dev.dejvokep.boostedyaml.YamlDocument;
 import io.tebex.plugin.command.BuyCommand;
 import io.tebex.plugin.command.TebexCommandExecutor;
 import io.tebex.plugin.event.InventoryClickListener;
-import io.tebex.plugin.event.PlayerJoinListener;
+import io.tebex.plugin.event.join.HuskSyncPlayerJoinListener;
+import io.tebex.plugin.event.join.PlayerJoinListener;
 import io.tebex.plugin.placeholder.BukkitNamePlaceholder;
 import io.tebex.sdk.Tebex;
 import io.tebex.sdk.obj.ServerEvent;
@@ -61,7 +62,13 @@ public final class TebexFoliaPlugin extends JavaPlugin {
         pluginCommand.setTabCompleter(tebexCommands);
 
         registerBuyCommandIfEnabled();
-        registerEvents(new PlayerJoinListener(platform));
+
+        if (getServer().getPluginManager().isPluginEnabled("HuskSync")) {
+            registerEvents(new HuskSyncPlayerJoinListener(platform));
+        } else {
+            registerEvents(new PlayerJoinListener(platform));
+        }
+
         registerEvents(new InventoryClickListener());
 
         PlaceholderManager placeholderManager = platform.getPlaceholderManager();

--- a/folia/src/main/java/io/tebex/plugin/event/join/HuskSyncPlayerJoinListener.java
+++ b/folia/src/main/java/io/tebex/plugin/event/join/HuskSyncPlayerJoinListener.java
@@ -1,0 +1,20 @@
+package io.tebex.plugin.event.join;
+
+import io.tebex.plugin.FoliaPluginPlatform;
+import net.william278.husksync.event.BukkitSyncCompleteEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+
+public class HuskSyncPlayerJoinListener extends JoinListenerBase {
+
+    public HuskSyncPlayerJoinListener(FoliaPluginPlatform platform) {
+        super(platform);
+    }
+
+    @EventHandler
+    private void onBukkitSyncCompleteEvent(BukkitSyncCompleteEvent event) {
+        if (event.getUser().getAudience() instanceof Player player) {
+            handlePlayerJoin(player);
+        }
+    }
+}

--- a/folia/src/main/java/io/tebex/plugin/event/join/JoinListenerBase.java
+++ b/folia/src/main/java/io/tebex/plugin/event/join/JoinListenerBase.java
@@ -1,22 +1,19 @@
-package io.tebex.plugin.event;
+package io.tebex.plugin.event.join;
 
-import io.tebex.plugin.BukkitPluginPlatform;
+import io.tebex.plugin.FoliaPluginPlatform;
 import io.tebex.sdk.obj.QueuedPlayer;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
 
-public class PlayerJoinListener implements Listener {
-    private final BukkitPluginPlatform platform;
+public abstract class JoinListenerBase implements Listener {
 
-    public PlayerJoinListener(BukkitPluginPlatform platform) {
+    private final FoliaPluginPlatform platform;
+
+    public JoinListenerBase(FoliaPluginPlatform platform) {
         this.platform = platform;
     }
 
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
+    protected void handlePlayerJoin(Player player) {
         Object playerId = platform.getPlayerId(player.getName(), player.getUniqueId());
         platform.createJoinEvent(player.getUniqueId().toString(), player.getName(), player.getAddress().getAddress().getHostAddress());
 

--- a/folia/src/main/java/io/tebex/plugin/event/join/PlayerJoinListener.java
+++ b/folia/src/main/java/io/tebex/plugin/event/join/PlayerJoinListener.java
@@ -1,0 +1,17 @@
+package io.tebex.plugin.event.join;
+
+import io.tebex.plugin.FoliaPluginPlatform;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class PlayerJoinListener extends JoinListenerBase {
+
+    public PlayerJoinListener(FoliaPluginPlatform platform) {
+        super(platform);
+    }
+
+    @EventHandler
+    private void onPlayerJoin(PlayerJoinEvent event) {
+        handlePlayerJoin(event.getPlayer());
+    }
+}

--- a/folia/src/main/resources/plugin.yml
+++ b/folia/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ api-version: 1.13
 folia-supported: true
 softdepend:
   - BuycraftX
+  - HuskSync
 commands:
   tebex:
     description: The main command

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -1,6 +1,7 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
     id("net.kyori.blossom") version "2.1.0"
-    id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.7"
 }
 
 sourceSets {
@@ -15,7 +16,7 @@ sourceSets {
 
 dependencies {
     implementation(project(":sdk"))
-    implementation("net.sf.trove4j:trove4j:3.0.3") // Add trove4j dependency
+    implementation("net.sf.trove4j:trove4j:3.0.3")
 
     compileOnly("com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")
     annotationProcessor("com.velocitypowered:velocity-api:3.3.0-SNAPSHOT")
@@ -27,18 +28,19 @@ tasks {
         options.release.set(17)
         options.encoding = Charsets.UTF_8.name()
     }
-    shadowJar {
-        configurations = listOf(project.configurations.runtimeClasspath.get())
+}
 
-        relocate("gnu.trove4j", "io.tebex.plugin.libs.trove4j") // Relocate trove4j
-        relocate("okhttp3", "io.tebex.plugin.libs.okhttp3") // Relocate okhttp
-        relocate("okio", "io.tebex.plugin.libs.okio") // Relocate okio (okhttp dependency)
-        relocate("dev.dejvokep.boostedyaml", "io.tebex.plugin.libs.boostedyaml") // Relocate boostedyaml
-        relocate("org.jetbrains.annotations", "io.tebex.plugin.libs.jetbrains") // Relocate jetbrains
-        relocate("kotlin", "io.tebex.plugin.libs.kotlin") // Relocate jetbrains
-        relocate("com.google.gson", "io.tebex.plugin.libs.gson") // Relocate gson
-        minimize()
-    }
+tasks.named("shadowJar", ShadowJar::class.java) {
+    configurations = listOf(project.configurations.runtimeClasspath.get())
+
+    relocate("gnu.trove4j", "io.tebex.plugin.libs.trove4j")
+    relocate("okhttp3", "io.tebex.plugin.libs.okhttp3")
+    relocate("okio", "io.tebex.plugin.libs.okio")
+    relocate("dev.dejvokep.boostedyaml", "io.tebex.plugin.libs.boostedyaml")
+    relocate("org.jetbrains.annotations", "io.tebex.plugin.libs.jetbrains")
+    relocate("kotlin", "io.tebex.plugin.libs.kotlin")
+    relocate("com.google.gson", "io.tebex.plugin.libs.gson")
+    minimize()
 }
 
 java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))


### PR DESCRIPTION
This PR refactors player join handling for Bukkit and Folia to support servers using HuskSync. When HuskSync is detected, Tebex now waits for the HuskSync sync-complete event before processing queued player commands, helping avoid running join logic before player data has finished syncing.