### PR TITLE
Support spaces in usernames for commands

### DIFF
--- a/sdk/src/main/java/io/tebex/sdk/SDK.java
+++ b/sdk/src/main/java/io/tebex/sdk/SDK.java
@@ -776,7 +776,8 @@ public class SDK {
             return null;
         }
 
-        return request("/user/" + username).withSecretKey(secretKey).sendAsync().thenApply(response -> {
+        String encodedUsername = username.replace(" ", "%20");
+        return request("/user/" + encodedUsername).withSecretKey(secretKey).sendAsync().thenApply(response -> {
             if(response.code() != 200 && response.code() != 404 && response.code() != 400) {
                 CompletionException e = new CompletionException(new IOException("Unexpected status code (" + response.code() + ")"));
                 platform.error("Unexpected failure while looking up player information", e);

--- a/sdk/src/main/java/io/tebex/sdk/commands/Context.java
+++ b/sdk/src/main/java/io/tebex/sdk/commands/Context.java
@@ -2,7 +2,9 @@ package io.tebex.sdk.commands;
 
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -28,6 +30,7 @@ import java.util.UUID;
 
         // Split out the prefix from the actual command so we don't count the subcommand as an argument
         command = command.replaceAll(TebexCommands.TEBEX_COMMAND_PREFIX + " ", "");
+        arguments = parseQuotedArguments(arguments);
         if (arguments.length > 0) {
             this.commandName = command.split(" ")[0];
             this.arguments = Arrays.copyOfRange(arguments, 1, arguments.length);
@@ -35,6 +38,45 @@ import java.util.UUID;
             this.commandName = command;
             this.arguments = new String[0];
         }
+    }
+
+    private String[] parseQuotedArguments(String[] arguments) {
+        List<String> parsedArguments = new ArrayList<>();
+        StringBuilder quotedArgument = new StringBuilder();
+        boolean inQuote = false;
+
+        for (String argument : arguments) {
+            if (!inQuote && argument.startsWith("\"")) {
+                inQuote = true;
+                quotedArgument.append(argument.substring(1));
+                if (argument.endsWith("\"") && argument.length() > 1) {
+                    inQuote = false;
+                    quotedArgument.setLength(quotedArgument.length() - 1);
+                    parsedArguments.add(quotedArgument.toString());
+                    quotedArgument.setLength(0);
+                }
+                continue;
+            }
+
+            if (inQuote) {
+                quotedArgument.append(" ").append(argument);
+                if (argument.endsWith("\"")) {
+                    inQuote = false;
+                    quotedArgument.setLength(quotedArgument.length() - 1);
+                    parsedArguments.add(quotedArgument.toString());
+                    quotedArgument.setLength(0);
+                }
+                continue;
+            }
+
+            parsedArguments.add(argument);
+        }
+
+        if (inQuote) {
+            parsedArguments.add(quotedArgument.toString());
+        }
+
+        return parsedArguments.toArray(new String[0]);
     }
 
     public static Context from(boolean isConsole, String senderUsername, UUID senderUUID, String fullCommand, String targetUsername, UUID targetUUID, String[] allArguments) {

--- a/sdk/src/main/java/io/tebex/sdk/commands/TebexCommands.java
+++ b/sdk/src/main/java/io/tebex/sdk/commands/TebexCommands.java
@@ -37,6 +37,10 @@ public class TebexCommands {
         commands.put(name, command);
     }
 
+    private static String joinArguments(String[] arguments, int startIndex) {
+        return String.join(" ", Arrays.copyOfRange(arguments, startIndex, arguments.length));
+    }
+
     public static Map<String, PlayerCommand> getCommands() {
         return Collections.unmodifiableMap(commands);
     }
@@ -126,9 +130,10 @@ public class TebexCommands {
         TebexCommands.platform = platform;
 
         register("ban","<playerName> <reason> <ip>", "Bans a user from the webstore.", (ctx) -> {
-            String name = ctx.getArguments()[0]; // player may be offline, so don't rely on target username which requires successful getPlayer() call
-            String reason = ctx.getArguments()[1];
-            String ip = ctx.getArguments()[2];
+            String[] arguments = ctx.getArguments();
+            String name = String.join(" ", Arrays.copyOfRange(arguments, 0, arguments.length - 2)); // player may be offline, so don't rely on target username which requires successful getPlayer() call
+            String reason = arguments[arguments.length - 2];
+            String ip = arguments[arguments.length - 1];
 
             CompletableFuture<String[]> response = new CompletableFuture<>();
             platform.getSDK().createBan(name, ip, reason).thenAccept((success) -> {
@@ -246,7 +251,7 @@ public class TebexCommands {
         register("lookup", "<username>", "Gets user transaction info from your webstore.", (ctx) -> {
             CompletableFuture<String[]> response = new CompletableFuture<>();
 
-            String username = ctx.getArguments()[0]; // Use provided username as player is not required to be online / no instance required
+            String username = joinArguments(ctx.getArguments(), 0); // Use provided username as player is not required to be online / no instance required
             platform.getSDK().getPlayerLookupInfo(username).thenAccept((lookupInfo) -> {
                 ArrayList<String> lookupResponse = new ArrayList<>();
                 lookupResponse.add(Responder.formatFancy(ctx, "Username: {0}", lookupInfo.getPlayer().getUsername()));
@@ -308,7 +313,7 @@ public class TebexCommands {
         register("sendlink", "<packageId> <username>", "Sends a purchase link to a player.", (ctx) -> {
             CompletableFuture<String[]> response = new CompletableFuture<>();
             String packageId = ctx.getArguments()[0];
-            String username = ctx.getArguments()[1];
+            String username = joinArguments(ctx.getArguments(), 1);
             int intPackageId = -1;
 
             try {
@@ -318,14 +323,14 @@ public class TebexCommands {
                 return response;
             }
 
-            if (ctx.getTargetUsername().isEmpty()) { // target will be empty if player was offline / no entity found
+            if (platform.getPlayer(username) == null) {
                 response.complete(new String[]{Responder.formatError(ctx, username + " must be online to receive a package link.")});
                 return response;
             }
 
-            platform.getSDK().createCheckoutUrl(intPackageId, ctx.getTargetUsername()).thenAccept(checkoutUrl -> {
-                platform.sendCheckoutLink(ctx.getTargetUsername(), checkoutUrl.getUrl());
-                response.complete(new String[]{Responder.formatSuccess(ctx, "Checkout link sent to " + ctx.getTargetUsername())});
+            platform.getSDK().createCheckoutUrl(intPackageId, username).thenAccept(checkoutUrl -> {
+                platform.sendCheckoutLink(username, checkoutUrl.getUrl());
+                response.complete(new String[]{Responder.formatSuccess(ctx, "Checkout link sent to " + username)});
             }).exceptionally(e -> {
                 response.complete(new String[]{Responder.formatError(ctx, "Failed to send checkout link: " + e.getMessage())});
                 return null;

--- a/velocity/src/main/java/io/tebex/plugin/command/TebexCommand.java
+++ b/velocity/src/main/java/io/tebex/plugin/command/TebexCommand.java
@@ -5,6 +5,7 @@ import io.tebex.plugin.manager.CommandManager;
 import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.command.CommandSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class TebexCommand implements SimpleCommand {
             return;
         }
 
-        subCommand.execute(sender, Arrays.copyOfRange(args, 1, args.length));
+        subCommand.execute(sender, parseQuotedArguments(Arrays.copyOfRange(args, 1, args.length)));
     }
 
     @Override
@@ -68,5 +69,44 @@ public class TebexCommand implements SimpleCommand {
             .filter(command -> source.hasPermission(command.getPermission()))
             .map(SubCommand::getName)
             .collect(Collectors.toList());
+    }
+
+    private String[] parseQuotedArguments(String[] arguments) {
+        List<String> parsedArguments = new ArrayList<>();
+        StringBuilder quotedArgument = new StringBuilder();
+        boolean inQuote = false;
+
+        for (String argument : arguments) {
+            if (!inQuote && argument.startsWith("\"")) {
+                inQuote = true;
+                quotedArgument.append(argument.substring(1));
+                if (argument.endsWith("\"") && argument.length() > 1) {
+                    inQuote = false;
+                    quotedArgument.setLength(quotedArgument.length() - 1);
+                    parsedArguments.add(quotedArgument.toString());
+                    quotedArgument.setLength(0);
+                }
+                continue;
+            }
+
+            if (inQuote) {
+                quotedArgument.append(" ").append(argument);
+                if (argument.endsWith("\"")) {
+                    inQuote = false;
+                    quotedArgument.setLength(quotedArgument.length() - 1);
+                    parsedArguments.add(quotedArgument.toString());
+                    quotedArgument.setLength(0);
+                }
+                continue;
+            }
+
+            parsedArguments.add(argument);
+        }
+
+        if (inQuote) {
+            parsedArguments.add(quotedArgument.toString());
+        }
+
+        return parsedArguments.toArray(new String[0]);
     }
 }

--- a/velocity/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
+++ b/velocity/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
@@ -4,6 +4,7 @@ import com.velocitypowered.api.command.CommandSource;
 import io.tebex.plugin.TebexVelocityPlugin;
 import io.tebex.plugin.command.SubCommand;
 
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
@@ -26,11 +27,12 @@ public class BanCommand extends SubCommand {
         String reason = "";
         String ip = "";
 
-        if (args.length > 1) { // second param provided
+        if (args.length > 2) { // reason and ip provided
+            playerName = String.join(" ", Arrays.copyOfRange(args, 0, args.length - 2));
+            reason = args[args.length - 2];
+            ip = args[args.length - 1];
+        } else if (args.length > 1) { // second param provided
             reason = args[1];
-        }
-        if (args.length > 2) { // third param provided
-            ip = args[2];
         }
 
         if (!platform.isSetup()) {


### PR DESCRIPTION
Added support for spaces in Bedrock-usernames, because Bedrock usernames can have spaces in them.

Users should "encapsulate usernames" that have spaces in them with "".

- Support usernames with spaces in Tebex commands that accept usernames.
- Allow quoted usernames, e.g. "callum5771" or "callum 5771".
- Preserve trailing username args for commands like 'lookup' and 'sendlink'.
- Encode lookup usernames safely for `/user/<username>` requests.