### PR TITLE
Feat: Spaced Usernames for Bedrock Support

### DIFF
--- a/sdk/src/main/java/io/tebex/sdk/SDK.java
+++ b/sdk/src/main/java/io/tebex/sdk/SDK.java
@@ -21,6 +21,8 @@ import okhttp3.OkHttpClient;
 import okhttp3.ResponseBody;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -776,7 +778,7 @@ public class SDK {
             return null;
         }
 
-        return request("/user/" + username).withSecretKey(secretKey).sendAsync().thenApply(response -> {
+        return request("/user/" + encodePathSegment(username)).withSecretKey(secretKey).sendAsync().thenApply(response -> {
             if(response.code() != 200 && response.code() != 404 && response.code() != 400) {
                 CompletionException e = new CompletionException(new IOException("Unexpected status code (" + response.code() + ")"));
                 platform.error("Unexpected failure while looking up player information", e);
@@ -806,6 +808,14 @@ public class SDK {
                 throw new CompletionException(e);
             }
         });
+    }
+
+    private String encodePathSegment(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+        } catch (UnsupportedEncodingException e) {
+            throw new CompletionException(e);
+        }
     }
 
     /**

--- a/sdk/src/main/java/io/tebex/sdk/commands/CommandArguments.java
+++ b/sdk/src/main/java/io/tebex/sdk/commands/CommandArguments.java
@@ -1,0 +1,29 @@
+package io.tebex.sdk.commands;
+
+import java.util.Arrays;
+
+public final class CommandArguments {
+    private CommandArguments() {}
+
+    public static String join(String[] arguments, int startIndex) {
+        return join(arguments, startIndex, arguments.length);
+    }
+
+    public static String join(String[] arguments, int startIndex, int endIndex) {
+        if (arguments == null || startIndex >= arguments.length || startIndex >= endIndex) {
+            return "";
+        }
+
+        int safeStartIndex = Math.max(0, startIndex);
+        int safeEndIndex = Math.min(arguments.length, endIndex);
+        return stripWrappingQuotes(String.join(" ", Arrays.copyOfRange(arguments, safeStartIndex, safeEndIndex)));
+    }
+
+    private static String stripWrappingQuotes(String argument) {
+        if (argument.length() >= 2 && argument.startsWith("\"") && argument.endsWith("\"")) {
+            return argument.substring(1, argument.length() - 1);
+        }
+
+        return argument;
+    }
+}

--- a/sdk/src/main/java/io/tebex/sdk/commands/TebexCommands.java
+++ b/sdk/src/main/java/io/tebex/sdk/commands/TebexCommands.java
@@ -126,9 +126,10 @@ public class TebexCommands {
         TebexCommands.platform = platform;
 
         register("ban","<playerName> <reason> <ip>", "Bans a user from the webstore.", (ctx) -> {
-            String name = ctx.getArguments()[0]; // player may be offline, so don't rely on target username which requires successful getPlayer() call
-            String reason = ctx.getArguments()[1];
-            String ip = ctx.getArguments()[2];
+            String[] arguments = ctx.getArguments();
+            String name = CommandArguments.join(arguments, 0, arguments.length - 2); // player may be offline, so don't rely on target username which requires successful getPlayer() call
+            String reason = arguments[arguments.length - 2];
+            String ip = arguments[arguments.length - 1];
 
             CompletableFuture<String[]> response = new CompletableFuture<>();
             platform.getSDK().createBan(name, ip, reason).thenAccept((success) -> {
@@ -246,7 +247,7 @@ public class TebexCommands {
         register("lookup", "<username>", "Gets user transaction info from your webstore.", (ctx) -> {
             CompletableFuture<String[]> response = new CompletableFuture<>();
 
-            String username = ctx.getArguments()[0]; // Use provided username as player is not required to be online / no instance required
+            String username = CommandArguments.join(ctx.getArguments(), 0); // Use provided username as player is not required to be online / no instance required
             platform.getSDK().getPlayerLookupInfo(username).thenAccept((lookupInfo) -> {
                 ArrayList<String> lookupResponse = new ArrayList<>();
                 lookupResponse.add(Responder.formatFancy(ctx, "Username: {0}", lookupInfo.getPlayer().getUsername()));
@@ -308,7 +309,7 @@ public class TebexCommands {
         register("sendlink", "<packageId> <username>", "Sends a purchase link to a player.", (ctx) -> {
             CompletableFuture<String[]> response = new CompletableFuture<>();
             String packageId = ctx.getArguments()[0];
-            String username = ctx.getArguments()[1];
+            String username = CommandArguments.join(ctx.getArguments(), 1);
             int intPackageId = -1;
 
             try {
@@ -318,14 +319,14 @@ public class TebexCommands {
                 return response;
             }
 
-            if (ctx.getTargetUsername().isEmpty()) { // target will be empty if player was offline / no entity found
+            if (platform.getPlayer(username) == null) {
                 response.complete(new String[]{Responder.formatError(ctx, username + " must be online to receive a package link.")});
                 return response;
             }
 
-            platform.getSDK().createCheckoutUrl(intPackageId, ctx.getTargetUsername()).thenAccept(checkoutUrl -> {
-                platform.sendCheckoutLink(ctx.getTargetUsername(), checkoutUrl.getUrl());
-                response.complete(new String[]{Responder.formatSuccess(ctx, "Checkout link sent to " + ctx.getTargetUsername())});
+            platform.getSDK().createCheckoutUrl(intPackageId, username).thenAccept(checkoutUrl -> {
+                platform.sendCheckoutLink(username, checkoutUrl.getUrl());
+                response.complete(new String[]{Responder.formatSuccess(ctx, "Checkout link sent to " + username)});
             }).exceptionally(e -> {
                 response.complete(new String[]{Responder.formatError(ctx, "Failed to send checkout link: " + e.getMessage())});
                 return null;

--- a/sdk/src/test/java/io/tebex/sdk/commands/CommandArgumentsTest.java
+++ b/sdk/src/test/java/io/tebex/sdk/commands/CommandArgumentsTest.java
@@ -1,0 +1,42 @@
+package io.tebex.sdk.commands;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CommandArgumentsTest {
+    @Test
+    void joinsUsernameFromRemainingArguments() {
+        String[] args = {"123", ".Bedrock", "Player", "Name"};
+
+        assertEquals(".Bedrock Player Name", CommandArguments.join(args, 1));
+    }
+
+    @Test
+    void removesWrappingQuotesFromJoinedUsername() {
+        String[] args = {"123", "\".Bedrock", "Player", "Name\""};
+
+        assertEquals(".Bedrock Player Name", CommandArguments.join(args, 1));
+    }
+
+    @Test
+    void joinsUsernameBeforeTrailingArguments() {
+        String[] args = {".Bedrock", "Player", "Name", "reason", "127.0.0.1"};
+
+        assertEquals(".Bedrock Player Name", CommandArguments.join(args, 0, args.length - 2));
+    }
+
+    @Test
+    void removesWrappingQuotesBeforeTrailingArguments() {
+        String[] args = {"\".Bedrock", "Player", "Name\"", "reason", "127.0.0.1"};
+
+        assertEquals(".Bedrock Player Name", CommandArguments.join(args, 0, args.length - 2));
+    }
+
+    @Test
+    void returnsEmptyStringForInvalidRange() {
+        String[] args = {"lookup"};
+
+        assertEquals("", CommandArguments.join(args, 2));
+    }
+}

--- a/velocity/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
+++ b/velocity/src/main/java/io/tebex/plugin/command/sub/BanCommand.java
@@ -3,6 +3,7 @@ package io.tebex.plugin.command.sub;
 import com.velocitypowered.api.command.CommandSource;
 import io.tebex.plugin.TebexVelocityPlugin;
 import io.tebex.plugin.command.SubCommand;
+import io.tebex.sdk.commands.CommandArguments;
 
 import java.util.concurrent.ExecutionException;
 
@@ -22,15 +23,15 @@ public class BanCommand extends SubCommand {
             return;
         }
 
-        String playerName = args[0];
+        String playerName = CommandArguments.join(args, 0, Math.max(1, args.length - 2));
         String reason = "";
         String ip = "";
 
-        if (args.length > 1) { // second param provided
+        if (args.length > 2) { // reason and ip provided
+            reason = args[args.length - 2];
+            ip = args[args.length - 1];
+        } else if (args.length > 1) { // second param provided
             reason = args[1];
-        }
-        if (args.length > 2) { // third param provided
-            ip = args[2];
         }
 
         if (!platform.isSetup()) {


### PR DESCRIPTION
This PR adds native support for usernames that contain spaces without requiring users to wrap those names in quotes. This keeps normal command usage working for Bedrock names such as `.Bedrock Player`, while still preserving support for quoted names like `".Bedrock Player"`.

Commands are now to be handled as so:
- `/tebex lookup .Bedrock Player`
- `/tebex sendlink <packageId> .Bedrock Player`
- `/tebex ban .Bedrock Player <reason> <ip>`

and their quoted variants,
- `/tebex lookup ".Bedrock Player"`
- `/tebex sendlink <packageId> ".Bedrock Player"`
- `/tebex ban ".Bedrock Player" <reason> <ip>`

This is a further improvement from PR #154 in which spaced usernames are not required to be in quotes, rather they work with AND without to ensure consistency across the board.
